### PR TITLE
Avoid crash when targetStats[version] is undefined

### DIFF
--- a/src/providers/CanIUseProvider.js
+++ b/src/providers/CanIUseProvider.js
@@ -85,7 +85,7 @@ export function getUnsupportedTargets(node: Node, targets: Targets): Array<strin
           ? targetStats[statsVersion].includes('n')
           : false)
       )
-      : targetStats[version].includes('n');
+      : targetStats[version] && targetStats[version].includes('n');
   })
   .map(formatTargetNames);
 }


### PR DESCRIPTION
May happen if browserslist returns a browser version that is newer than what's in the caniuse-db.

This is probably not the best solution -- maybe it should parse and decrement the version number until it finds something that is in the database, but it at least avoids a crash.