### PR TITLE
Update browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "browserslist": "^2.11.3",
+    "browserslist": "^3.2.7",
     "caniuse-db": "^1.0.30000794",
     "mdn-browser-compat-data": "^0.0.20",
     "requireindex": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "browserslist": "^3.2.7",
-    "caniuse-db": "^1.0.30000794",
+    "caniuse-db": "^1.0.30000843",
     "mdn-browser-compat-data": "^0.0.20",
     "requireindex": "^1.1.0"
   },

--- a/test/__snapshots__/Versioning.spec.js.snap
+++ b/test/__snapshots__/Versioning.spec.js.snap
@@ -28,14 +28,14 @@ Array [
     "version": "4",
   },
   Object {
-    "parsedVersion": 9.1,
+    "parsedVersion": 10,
     "target": "safari",
-    "version": "9.1",
+    "version": "10",
   },
   Object {
-    "parsedVersion": 46,
+    "parsedVersion": 50,
     "target": "opera",
-    "version": "46",
+    "version": "50",
   },
   Object {
     "parsedVersion": 11.5,
@@ -48,9 +48,9 @@ Array [
     "version": "all",
   },
   Object {
-    "parsedVersion": 9.3,
+    "parsedVersion": 10,
     "target": "ios_saf",
-    "version": "9.3",
+    "version": "10.0-10.2",
   },
   Object {
     "parsedVersion": 10,
@@ -68,14 +68,14 @@ Array [
     "version": "52",
   },
   Object {
-    "parsedVersion": 13,
+    "parsedVersion": 14,
     "target": "edge",
-    "version": "13",
+    "version": "14",
   },
   Object {
-    "parsedVersion": 60,
+    "parsedVersion": 63,
     "target": "chrome",
-    "version": "60",
+    "version": "63",
   },
   Object {
     "parsedVersion": 7,
@@ -93,9 +93,9 @@ Array [
     "version": "4.2-4.3",
   },
   Object {
-    "parsedVersion": 11.4,
+    "parsedVersion": 11.8,
     "target": "and_uc",
-    "version": "11.4",
+    "version": "11.8",
   },
   Object {
     "parsedVersion": 1.2,
@@ -103,14 +103,14 @@ Array [
     "version": "1.2",
   },
   Object {
-    "parsedVersion": 57,
+    "parsedVersion": 60,
     "target": "and_ff",
-    "version": "57",
+    "version": "60",
   },
   Object {
-    "parsedVersion": 62,
+    "parsedVersion": 66,
     "target": "and_chr",
-    "version": "62",
+    "version": "66",
   },
 ]
 `;
@@ -123,14 +123,14 @@ Array [
     "version": "4",
   },
   Object {
-    "parsedVersion": 9.1,
+    "parsedVersion": 10,
     "target": "safari",
-    "version": "9.1",
+    "version": "10",
   },
   Object {
-    "parsedVersion": 46,
+    "parsedVersion": 50,
     "target": "opera",
-    "version": "46",
+    "version": "50",
   },
   Object {
     "parsedVersion": 11.5,
@@ -143,9 +143,9 @@ Array [
     "version": "all",
   },
   Object {
-    "parsedVersion": 9.3,
+    "parsedVersion": 10,
     "target": "ios_saf",
-    "version": "9.3",
+    "version": "10.0-10.2",
   },
   Object {
     "parsedVersion": 10,
@@ -163,14 +163,14 @@ Array [
     "version": "52",
   },
   Object {
-    "parsedVersion": 13,
+    "parsedVersion": 14,
     "target": "edge",
-    "version": "13",
+    "version": "14",
   },
   Object {
-    "parsedVersion": 54,
+    "parsedVersion": 57,
     "target": "chrome",
-    "version": "54",
+    "version": "57",
   },
   Object {
     "parsedVersion": 7,
@@ -188,9 +188,9 @@ Array [
     "version": "4.2-4.3",
   },
   Object {
-    "parsedVersion": 11.4,
+    "parsedVersion": 11.8,
     "target": "and_uc",
-    "version": "11.4",
+    "version": "11.8",
   },
   Object {
     "parsedVersion": 1.2,
@@ -198,14 +198,14 @@ Array [
     "version": "1.2",
   },
   Object {
-    "parsedVersion": 57,
+    "parsedVersion": 60,
     "target": "and_ff",
-    "version": "57",
+    "version": "60",
   },
   Object {
-    "parsedVersion": 62,
+    "parsedVersion": 66,
     "target": "and_chr",
-    "version": "62",
+    "version": "66",
   },
 ]
 `;

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -42,7 +42,7 @@ ruleTester.run('compat', rule, {
     },
     {
       code: 'new IntersectionObserver(() => {}, {});',
-      settings: { browsers: ['chrome 57'] }
+      settings: { browsers: ['chrome 58'] }
     },
     {
       code: "new URL('http://example')",
@@ -95,11 +95,11 @@ ruleTester.run('compat', rule, {
       code: 'WebAssembly.compile()',
       settings: {
         browsers: [
-          'Samsung 4', 'Safari 10.1', 'Opera 12.1', 'OperaMini all', 'iOS 10.3', 'ExplorerMobile 10', 'IE 10', 'Edge 14', 'Blackberry 7', 'Baidu 7.12', 'UCAndroid 11.4', 'QQAndroid 1.2'
+          'Samsung 4', 'Safari 10.1', 'Opera 12.1', 'OperaMini all', 'iOS 10.3', 'ExplorerMobile 10', 'IE 10', 'Edge 14', 'Blackberry 7', 'Baidu 7.12', 'UCAndroid 11.8', 'QQAndroid 1.2'
         ]
       },
       errors: [{
-        message: 'WebAssembly is not supported in Samsung Browser 4, Safari 10.1, Opera 12.1, Opera Mini all, iOS Safari 10.3, IE Mobile 10, IE 10, Edge 14, Blackberry Browser 7, Baidu 7.12, Android UC Browser 11.4, QQ Browser 1.2',
+        message: 'WebAssembly is not supported in Samsung Browser 4, Safari 10.1, Opera 12.1, Opera Mini all, iOS Safari 10.3, IE Mobile 10, IE 10, Edge 14, Blackberry Browser 7, Baidu 7.12, Android UC Browser 11.8, QQ Browser 1.2',
         type: 'MemberExpression'
       }]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,12 +1056,19 @@ browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
-browserslist@^2.1.2, browserslist@^2.11.3, browserslist@^2.5.1:
+browserslist@^2.1.2, browserslist@^2.5.1:
   version "2.11.3"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
   dependencies:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
+
+browserslist@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.7.tgz#aa488634d320b55e88bab0256184dbbcca1e6de9"
+  dependencies:
+    caniuse-lite "^1.0.30000835"
+    electron-to-chromium "^1.3.45"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -1133,6 +1140,10 @@ caniuse-db@^1.0.30000748, caniuse-db@^1.0.30000794:
 caniuse-lite@^1.0.30000792:
   version "1.0.30000792"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
+
+caniuse-lite@^1.0.30000835:
+  version "1.0.30000843"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000843.tgz#4fdec258dc641c385744cdd49d23c5459c3d4411"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1575,6 +1586,10 @@ ecc-jsbn@~0.1.1:
 electron-to-chromium@^1.3.30:
   version "1.3.31"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz#00d832cba9fe2358652b0c48a8816c8e3a037e9f"
+
+electron-to-chromium@^1.3.45:
+  version "1.3.47"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz#764e887ca9104d01a0ac8eabee7dfc0e2ce14104"
 
 emojis-list@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,9 +1133,13 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-db@^1.0.30000748, caniuse-db@^1.0.30000794:
+caniuse-db@^1.0.30000748:
   version "1.0.30000794"
   resolved "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000794.tgz#bbe71104fa277ce4b362387d54905e8b88e52f35"
+
+caniuse-db@^1.0.30000843:
+  version "1.0.30000843"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000843.tgz#4f7e8501f557dc9bcd37dd33ac85905c765efec2"
 
 caniuse-lite@^1.0.30000792:
   version "1.0.30000792"


### PR DESCRIPTION
Closes #112

Updated the tests for which the matching list of browsers has changed.

I ran into a bit of a problem with tests that were failing on the CI, but not for me. It was caused by a difference in dependency resolution between yarn and npm. Personally I don't include a lockfile with my libraries (see [here](https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514)) and I'd recommend removing the yarn lockfile.

Anyway, that is why I updated caniuse-db, because there was a mismatch between the version that npm and yarn were resolving. You could solve it differently, so let me know if you'd prefer to do so.