### PR TITLE
Inject isValid and getUnsupportedTargets in CanIUseProvider nodes isvalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ lib
 
 # Editor
 .idea
+.vscode/

--- a/src/providers/CanIUseProvider.js
+++ b/src/providers/CanIUseProvider.js
@@ -135,16 +135,12 @@ const CanIUseProvider: Array<Node> = [
     id: 'serviceworkers',
     ASTNodeType: 'NewExpression',
     object: 'ServiceWorker',
-    isValid,
-    getUnsupportedTargets
   },
   {
     id: 'serviceworkers',
     ASTNodeType: 'MemberExpression',
     object: 'navigator',
     property: 'serviceWorker',
-    isValid,
-    getUnsupportedTargets
   },
   // document.querySelector()
   {
@@ -152,80 +148,60 @@ const CanIUseProvider: Array<Node> = [
     ASTNodeType: 'MemberExpression',
     object: 'document',
     property: 'querySelector',
-    isValid,
-    getUnsupportedTargets
   },
   // WebAssembly
   {
     id: 'wasm',
     ASTNodeType: 'MemberExpression',
     object: 'WebAssembly',
-    isValid,
-    getUnsupportedTargets
   },
   // IntersectionObserver
   {
     id: 'intersectionobserver',
     ASTNodeType: 'NewExpression',
     object: 'IntersectionObserver',
-    isValid,
-    getUnsupportedTargets
   },
   // PaymentRequest
   {
     id: 'payment-request',
     ASTNodeType: 'NewExpression',
     object: 'PaymentRequest',
-    isValid,
-    getUnsupportedTargets
   },
   // Promises
   {
     id: 'promises',
     ASTNodeType: 'NewExpression',
     object: 'Promise',
-    isValid,
-    getUnsupportedTargets
   },
   {
     id: 'promises',
     ASTNodeType: 'MemberExpression',
     object: 'Promise',
     property: 'resolve',
-    isValid,
-    getUnsupportedTargets
   },
   {
     id: 'promises',
     ASTNodeType: 'MemberExpression',
     object: 'Promise',
     property: 'all',
-    isValid,
-    getUnsupportedTargets
   },
   {
     id: 'promises',
     ASTNodeType: 'MemberExpression',
     object: 'Promise',
     property: 'race',
-    isValid,
-    getUnsupportedTargets
   },
   {
     id: 'promises',
     ASTNodeType: 'MemberExpression',
     object: 'Promise',
     property: 'reject',
-    isValid,
-    getUnsupportedTargets
   },
   // fetch
   {
     id: 'fetch',
     ASTNodeType: 'CallExpression',
     object: 'fetch',
-    isValid,
-    getUnsupportedTargets
   },
   // document.currentScript()
   {
@@ -233,24 +209,18 @@ const CanIUseProvider: Array<Node> = [
     ASTNodeType: 'MemberExpression',
     object: 'document',
     property: 'currentScript',
-    isValid,
-    getUnsupportedTargets
   },
   // URL
   {
     id: 'url',
     ASTNodeType: 'NewExpression',
     object: 'URL',
-    isValid,
-    getUnsupportedTargets
   },
   // URLSearchParams
   {
     id: 'urlsearchparams',
     ASTNodeType: 'NewExpression',
     object: 'URLSearchParams',
-    isValid,
-    getUnsupportedTargets
   },
   // performance.now()
   {
@@ -258,9 +228,12 @@ const CanIUseProvider: Array<Node> = [
     ASTNodeType: 'MemberExpression',
     object: 'performance',
     property: 'now',
-    isValid,
-    getUnsupportedTargets
   },
-];
+].map(rule =>
+  Object.assign({}, rule, {
+    isValid,
+    getUnsupportedTargets,
+  })
+);
 
 export default CanIUseProvider;


### PR DESCRIPTION
nits refactor.

Adding `isValid()` and `getUnsupportedTargets()` every time when adding a new rule to CanIUseProvider seems redundant, so fixed it.

Add `.vscode` to .gitignore as well (this is a nits change, so I mixed this commit)

please review 🙏 