### PR TITLE
use ast-metadata-inferer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.0.0
+### Added
+- Support for ~4000 JS API's using [ast-metadata-inferer](https://github.com/amilajack/ast-metadata-inferer)
+
 ## v2.7.0
 ### Added
 - `Object.values()` support

--- a/README.md
+++ b/README.md
@@ -87,3 +87,8 @@ This project was inspired by a two hour conversation I had with someone on the e
 
 ## Demo
 For a minimal demo, see [amilajack/eslint-plugin-compat-demo](https://github.com/amilajack/eslint-plugin-compat-demo)
+
+## Related
+
+* [ast-metadata-inferer](https://github.com/amilajack/ast-metadata-inferer)
+* [compat-db](https://github.com/amilajack/compat-db)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "ast-metadata-inferer": "^0.1.1-2",
+    "ast-metadata-inferer": "^0.1.1-3",
     "browserslist": "^4.4.1",
     "caniuse-db": "^1.0.30000935",
     "mdn-browser-compat-data": "^0.0.66",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "homepage": "https://github.com/amilajack/eslint-plugin-compat#readme",
   "scripts": {
-    "build": "cross-env NODE_ENV=production rm -rf lib && babel src --out-dir lib",
+    "build": "cross-env NODE_ENV=production rm -rf lib && babel src --out-dir lib --source-maps inline",
     "flow": "flow",
     "flow-typed": "flow-typed install --ignoreDeps peer dev",
     "lint": "eslint --cache --format=node_modules/eslint-formatter-pretty .",
@@ -59,9 +59,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
+    "ast-metadata-inferer": "^0.1.1-0",
     "browserslist": "^4.4.1",
     "caniuse-db": "^1.0.30000935",
-    "mdn-browser-compat-data": "^0.0.66"
+    "mdn-browser-compat-data": "^0.0.66",
+    "semver": "^5.6.0"
   },
   "peerDependencies": {
     "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-compat",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "Lint browser compatibility of API used",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "ast-metadata-inferer": "^0.1.1-0",
+    "ast-metadata-inferer": "^0.1.1-2",
     "browserslist": "^4.4.1",
     "caniuse-db": "^1.0.30000935",
     "mdn-browser-compat-data": "^0.0.66",

--- a/src/Lint.js
+++ b/src/Lint.js
@@ -19,11 +19,11 @@ export default function Lint(
   targets: Targets = ['chrome', 'firefox', 'safari', 'edge'],
   polyfills: Set<string> = new Set()
 ): isValidObject {
-  // Find the corresponding rules for a eslintNode by it's ASTNodeType
+  // Find the corresponding rules for a eslintNode by it's astNodeType
   const failingRule = rules
     .filter(
       (rule: Node): boolean =>
-        rule.ASTNodeType === eslintNode.type &&
+        rule.astNodeType === eslintNode.type &&
         // Check if polyfill is provided
         !polyfills.has(rule.id)
     )

--- a/src/Lint.js
+++ b/src/Lint.js
@@ -1,5 +1,5 @@
 // @flow
-import { rules } from './providers/index';
+import { rules } from './providers';
 import type { Node, ESLintNode, Targets, isValidObject } from './LintTypes';
 
 export function generateErrorName(_node: Node): string {
@@ -17,7 +17,7 @@ export function generateErrorName(_node: Node): string {
 export default function Lint(
   eslintNode: ESLintNode,
   targets: Targets = ['chrome', 'firefox', 'safari', 'edge'],
-  polyfills: Set<string> = new Set()
+  polyfills: Set<string>
 ): isValidObject {
   // Find the corresponding rules for a eslintNode by it's astNodeType
   const failingRule = rules

--- a/src/LintTypes.js
+++ b/src/LintTypes.js
@@ -1,7 +1,9 @@
 // @flow
 export type node = {
-  type?: string,
-  name?: string
+  type?: 'MemberExpression' | 'NewExpression' | 'CallExpression',
+  name?: string,
+  object: string,
+  property: string | void
 };
 
 export type Target = {
@@ -24,7 +26,7 @@ export type ESLintNode = {
 } & node;
 
 export type Node = {
-  ASTNodeType: string,
+  astNodeType: string,
   id: string,
   object: string,
   property?: string,

--- a/src/Versioning.js
+++ b/src/Versioning.js
@@ -1,5 +1,5 @@
 // @flow
-import browserslist from 'browserslist'; // eslint-disable-line
+import browserslist from 'browserslist';
 import type { BrowserListConfig } from './rules/compat';
 
 type TargetListItem = {

--- a/src/providers/CanIUseProvider.js
+++ b/src/providers/CanIUseProvider.js
@@ -169,12 +169,6 @@ const CanIUseProvider: Array<Node> = [
     object: 'document',
     property: 'querySelector'
   },
-  // WebAssembly
-  {
-    id: 'wasm',
-    astNodeType: 'MemberExpression',
-    object: 'WebAssembly'
-  },
   // IntersectionObserver
   {
     id: 'intersectionobserver',

--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -78,6 +78,7 @@ export function mdnSupported(node: Node, { version, target }: Target): boolean {
 
   // If a version is true then it is supported but version is unsure
   if (typeof versionAdded === 'boolean') return versionAdded;
+  if (versionAdded === null) return false;
   // A browser supports an API if its version is greater than or equal
   // to the first version of the browser that API was added in
   return semver.gte(

--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -1,0 +1,161 @@
+import AstMetadata from 'ast-metadata-inferer';
+import semver from 'semver';
+import type { Node, ESLintNode, Targets, Target } from '../LintTypes';
+
+type AstMetadataRecordType = {
+  apiType: 'js-api' | 'css-api',
+  type: 'js-api' | 'css-api',
+  protoChain: Array<string>,
+  protoChainId: string,
+  astNodeTypes: Array<string>,
+  isStatic: boolean,
+  compat: {
+    support: {
+      [browserName: string]: {
+        // If a version is true then it is supported but version is unsure
+        version_added: string | boolean
+      }
+    },
+    [x: string]: any
+  }
+};
+
+const mdnRecords: Map<string, AstMetadataRecordType> = new Map(
+  AstMetadata.map(e => [e.protoChainId, e])
+);
+
+/**
+ * Map ids of mdn targets to their "common/friendly" name
+ */
+const targetNameMappings = {
+  chrome: 'Chrome',
+  firefox: 'Firefox',
+  opera: 'Opera',
+  safari: 'Safari',
+  ie: 'IE',
+  edge: 'Edge',
+  safari_ios: 'iOS Safari',
+  opera_android: 'Opera Mobile',
+  chrome_android: 'Android Chrome',
+  edge_mobile: 'Edge Mobile',
+  firefox_android: 'Android Firefox',
+  webview_android: 'WebView Android',
+  samsunginternet_android: 'Samsung Browser',
+  nodes: 'Node.js'
+};
+
+/**
+ * Take a target's id and return it's full name by using `targetNameMappings`
+ * ex. {target: and_ff, version: 40} => 'Android FireFox 40'
+ */
+function formatTargetNames(target: Target): string {
+  return `${targetNameMappings[target.target]} ${target.version}`;
+}
+
+/**
+ * Convert '9' => '9.0.0'
+ */
+function customCoerce(version: string): string {
+  return version.length === 1 ? [version, 0, 0].join('.') : version;
+}
+
+/*
+ * Return if MDN supports the API or not
+ */
+export function mdnSupported(node: Node, { version, target }: Target): boolean {
+  // If no record could be found, return false. Rules might not
+  // be found because they could belong to another provider
+  if (!mdnRecords.has(node.protoChainId)) return true;
+  const record = mdnRecords.get(node.protoChainId);
+  if (!record || !record.compat.support) return true;
+  const compatRecord = record.compat.support[target];
+  if (!compatRecord || !('version_added' in compatRecord)) return true;
+  const { version_added: versionAdded } = compatRecord;
+  // If a version is true then it is supported but version is unsure
+  if (typeof versionAdded === 'boolean') return versionAdded;
+  // A browser supports an API if its version is greater than or equal
+  // to the first version of the browser that API was added in
+  return semver.gte(
+    semver.coerce(customCoerce(version)),
+    semver.coerce(customCoerce(versionAdded))
+  );
+}
+
+/**
+ * Return an array of all unsupported targets
+ */
+export function getUnsupportedTargets(
+  node: Node,
+  targets: Targets
+): Array<string> {
+  return targets
+    .filter(target => !mdnSupported(node, target))
+    .map(formatTargetNames);
+}
+
+/**
+ * Check if the node has matching object or properties
+ */
+function isValid(
+  node: Node,
+  eslintNode: ESLintNode,
+  targets: Targets
+): boolean {
+  switch (eslintNode.type) {
+    case 'CallExpression':
+    case 'NewExpression':
+      if (!eslintNode.callee) return true;
+      if (eslintNode.callee.name !== node.object) return true;
+      break;
+    case 'MemberExpression':
+      // Pass tests if non-matching object or property
+      if (!eslintNode.object || !eslintNode.property) return true;
+      if (eslintNode.object.name !== node.object) return true;
+
+      // If the property is missing from the rule, it means that only the
+      // object is required to determine compatibility
+      if (!node.property) break;
+
+      if (eslintNode.property.name !== node.property) return true;
+      break;
+    default:
+      return true;
+  }
+
+  return !getUnsupportedTargets(node, targets).length;
+}
+
+function getMetadataName(metadata: Node) {
+  switch (metadata.protoChain.length) {
+    case 1: {
+      return metadata.protoChain[0];
+    }
+    default:
+      return `${metadata.protoChain.join('.')}()`;
+  }
+}
+
+const MdnProvider: Array<Node> = AstMetadata
+  // Create entries for each ast node type
+  .map(metadata =>
+    metadata.astNodeTypes.map(astNodeType => ({
+      ...metadata,
+      name: getMetadataName(metadata),
+      id: metadata.protoChainId,
+      astNodeType,
+      object: metadata.protoChain[0],
+      // @TODO Handle cases where 'prototype' is in protoChain
+      property: metadata.protoChain[1]
+    }))
+  )
+  // Flatten the array of arrays
+  .reduce((p, c) => [...p, ...c])
+  // Add rule and target support logic for each entry
+  .map(rule =>
+    Object.assign({}, rule, {
+      isValid,
+      getUnsupportedTargets
+    })
+  );
+
+export default MdnProvider;

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,8 +1,7 @@
 // @flow
-import Kangax from './KangaxProvider';
 import CanIUse from './CanIUseProvider';
+import Mdn from './MdnProvider';
 import type { Node } from '../LintTypes';
 
-export const rules: Array<Node> = [...Kangax, ...CanIUse];
-
-export default {};
+// eslint-disable-next-line import/prefer-default-export
+export const rules: Array<Node> = [...CanIUse, ...Mdn];

--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -1,10 +1,10 @@
 // @flow
 import Lint, { generateErrorName } from '../Lint';
 import DetermineTargetsFromConfig, { Versioning } from '../Versioning';
-import type { ESLintNode, Node } from '../LintTypes'; // eslint-disable-line
+import type { ESLintNode } from '../LintTypes';
 
 type ESLint = {
-  [ASTNodeTypeName: string]: (node: ESLintNode) => void
+  [astNodeTypeName: string]: (node: ESLintNode) => void
 };
 
 type Context = {

--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -49,9 +49,7 @@ export default {
       const { isValid, rule, unsupportedTargets } = Lint(
         node,
         browserslistTargets,
-        context.settings.polyfills
-          ? new Set(context.settings.polyfills)
-          : undefined
+        new Set(context.settings.polyfills || [])
       );
 
       if (!isValid) {

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -51,15 +51,6 @@ ruleTester.run('compat', rule, {
     }
   ],
   invalid: [
-    // TODO: Atomcis are not yet supported by caniuse
-    //
-    // {
-    //   code: 'Atomics.store()',
-    //   errors: [{
-    //     message: 'Unsupported API being used',
-    //     type: 'MemberExpression'
-    //   }]
-    // },
     {
       code: 'Object.values({})',
       settings: { browsers: ['safari 9'] },

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -27,7 +27,10 @@ ruleTester.run('compat', rule, {
     },
     {
       code: 'WebAssembly.compile()',
-      settings: { polyfills: ['wasm'] }
+      settings: {
+        browsers: ['chrome 40'],
+        polyfills: ['WebAssembly', 'WebAssembly.compile']
+      }
     },
     {
       code: 'new IntersectionObserver(() => {}, {});',
@@ -51,6 +54,16 @@ ruleTester.run('compat', rule, {
     }
   ],
   invalid: [
+    {
+      code: 'new AnimationEvent',
+      settings: { browsers: ['chrome 40'] },
+      errors: [
+        {
+          message: 'AnimationEvent is not supported in Chrome 40',
+          type: 'NewExpression'
+        }
+      ]
+    },
     {
       code: 'Object.values({})',
       settings: { browsers: ['safari 9'] },
@@ -102,7 +115,7 @@ ruleTester.run('compat', rule, {
       errors: [
         {
           message:
-            'WebAssembly is not supported in Samsung Browser 4, Safari 10.1, Opera 12.1, Opera Mini all, iOS Safari 10.3, IE Mobile 10, IE 10, Edge 14, Blackberry Browser 7, Baidu 7.12, Android UC Browser 11.8, QQ Browser 1.2',
+            'WebAssembly is not supported in Safari 10.1, Opera 12.1, IE 10, Edge 14',
           type: 'MemberExpression'
         }
       ]

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -55,18 +55,6 @@ ruleTester.run('compat', rule, {
   ],
   invalid: [
     {
-      code: 'new MediaRecorder()',
-      settings: {
-        browsers: ['ie 9']
-      },
-      errors: [
-        {
-          message: 'MediaRecorder is not supported in IE 9',
-          type: 'NewExpression'
-        }
-      ]
-    },
-    {
       code: 'new AnimationEvent',
       settings: { browsers: ['chrome 40'] },
       errors: [

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -55,6 +55,18 @@ ruleTester.run('compat', rule, {
   ],
   invalid: [
     {
+      code: 'new MediaRecorder()',
+      settings: {
+        browsers: ['ie 9']
+      },
+      errors: [
+        {
+          message: 'MediaRecorder is not supported in IE 9',
+          type: 'NewExpression'
+        }
+      ]
+    },
+    {
       code: 'new AnimationEvent',
       settings: { browsers: ['chrome 40'] },
       errors: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,10 +849,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-metadata-inferer@^0.1.1-0:
-  version "0.1.1-0"
-  resolved "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1-0.tgz#5e01f3129a95b0bdc913099c675afbabb6a481c6"
-  integrity sha512-7Fd+li7bk5KDX/FS/QCLjssNp0ul0chBPklUTjAWF3QyLCc7vK5ix0HC//usIipBDqsE1MSkAkx1219lz1+rcw==
+ast-metadata-inferer@^0.1.1-2:
+  version "0.1.1-2"
+  resolved "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1-2.tgz#7b7346435c2feb3937d25c0f4f9c701a6d4a26f4"
+  integrity sha512-bmpZzzGAzGsHH0EnfUomWhdsYNHwwlAU2jrlaaCT39vxO51TX3v4AxXLqoRGsdym+RGmXaORoLqnIAWLbeoacw==
 
 astral-regex@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,6 +849,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-metadata-inferer@^0.1.1-0:
+  version "0.1.1-0"
+  resolved "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1-0.tgz#5e01f3129a95b0bdc913099c675afbabb6a481c6"
+  integrity sha512-7Fd+li7bk5KDX/FS/QCLjssNp0ul0chBPklUTjAWF3QyLCc7vK5ix0HC//usIipBDqsE1MSkAkx1219lz1+rcw==
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -4969,7 +4974,7 @@ seek-bzip@^1.0.5:
   dependencies:
     commander "~2.8.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,10 +849,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-metadata-inferer@^0.1.1-2:
-  version "0.1.1-2"
-  resolved "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1-2.tgz#7b7346435c2feb3937d25c0f4f9c701a6d4a26f4"
-  integrity sha512-bmpZzzGAzGsHH0EnfUomWhdsYNHwwlAU2jrlaaCT39vxO51TX3v4AxXLqoRGsdym+RGmXaORoLqnIAWLbeoacw==
+ast-metadata-inferer@^0.1.1-3:
+  version "0.1.1-3"
+  resolved "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1-3.tgz#04d4c9ae158c27dca2ef957a93bfe9ba70c26ebb"
+  integrity sha512-z40cBIR8jZ7FL9fWptuDnY5E8DjTeQS2HIzQ4i+Mm3syDm7k57QqPkOcxGEk20Fk3J6jzSCidrsWXps3drmJpQ==
 
 astral-regex@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
[ast-metadata-inferer](https://github.com/amilajack/ast-metadata-inferer) is a complementary project of mine that does the following things:

* AST node type of the API (`MemberExpression`, `NewExpression`, or `CallExpression`)
* Determines if an API is statically invoked (ex. `document.querySelector()`)
* Determines if an API is a CSS or JS API
* Provides compatibility information from `mdn-browser-compat-data`

## Pros
* Adds support for ~4000 APIs 🎉 🎉 🎉 

## Cons
* Likely performance regressions because of the number of accesses to the significant increased number of compat records

## Todos
- [ ] extensive testing (probably by publishing the next branch and allowing users to test it) and test against large codebases

- Closes https://github.com/amilajack/eslint-plugin-compat/issues/104
- Closes https://github.com/amilajack/eslint-plugin-compat/issues/89