### PR TITLE
handle entire API polyfill case

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ Add polyfills to the settings section of your eslint config. Append the name of 
   // ...
   "settings": {
     "polyfills": [
-      "WebAssembly",
+      // Example of marking entire API and all methods and properties as polyfilled
+      "Promise",
+      // Example of marking specific method of an API as polyfilled
       "WebAssembly.compile",
-      // Example of API with no property
+      // Example of API with no property (i.e. a function)
       "fetch",
       // Example of instance method, must add `.prototype.`
       "Array.prototype.push"

--- a/src/Lint.js
+++ b/src/Lint.js
@@ -27,8 +27,10 @@ export default function Lint(
         // v2 allowed users to select polyfills based off their caniuseId. This is
         // no longer supported. Keeping this here to avoid breaking changes.
         !polyfills.has(rule.id) &&
-        // Check if polyfill is provided
-        !polyfills.has(rule.protoChainId)
+        // Check if polyfill is provided (ex. `Promise.all`)
+        !polyfills.has(rule.protoChainId) &&
+        // Check if entire API is polyfilled (ex. `Promise`)
+        !polyfills.has(rule.protoChain[0])
     )
     // Find the first failing rule
     .find((rule: Node): boolean => !rule.isValid(rule, eslintNode, targets));

--- a/src/LintTypes.js
+++ b/src/LintTypes.js
@@ -4,7 +4,8 @@ export type node = {
   name?: string,
   object: string,
   property: string | void,
-  protoChainId: string
+  protoChainId: string,
+  protoChain: Array<string>
 };
 
 export type Target = {

--- a/src/providers/CanIUseProvider.js
+++ b/src/providers/CanIUseProvider.js
@@ -247,7 +247,11 @@ const CanIUseProvider: Array<Node> = [
   Object.assign({}, rule, {
     isValid,
     getUnsupportedTargets,
-    id: rule.property ? `${rule.object}.${rule.property}` : rule.object
+    id: rule.property ? `${rule.object}.${rule.property}` : rule.object,
+    protoChainId: rule.property
+      ? `${rule.object}.${rule.property}`
+      : rule.object,
+    protoChain: rule.property ? [rule.object, rule.property] : [rule.object]
   })
 );
 


### PR DESCRIPTION
## Tasks
- [x] add test cases
- [ ] update CHANGELOG

Handle cases where entire API is polyfiled. Here's an example of the kind of cases this PR covers:
```jsonc
{
  // ...
  "settings": {
    "polyfills": [
      // Example of marking entire API and all methods and properties as polyfilled
      "Promise"
    ]
  }
}
```
This will mark all the following APIs as polyfilled: `Promise.all`, `Promise.race`, `Promise.prototype.then`, etc