### PR TITLE
Add browserlist config as eslint rule config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Alternatively, you can use the `recommended` configuration which will do this fo
 
 ## Targeting Browsers
 
-`eslint-plugin-compat` uses the browserslist configuration in `package.json`. If no configuration is found, browserslist [defaults to](https://github.com/browserslist/browserslist#queries) `> 0.5%, last 2 versions, Firefox ESR, not dead`.
+`eslint-plugin-compat` uses the browserslist configuration in `package.json` or the rule configuration in `.eslintrc.*`. If no configuration is found, browserslist [defaults to](https://github.com/browserslist/browserslist#queries) `> 0.5%, last 2 versions, Firefox ESR, not dead`.
 
 See [browserslist/browserslist](https://github.com/browserslist/browserslist) for configuration. Here's some examples:
 
@@ -58,6 +58,15 @@ See [browserslist/browserslist](https://github.com/browserslist/browserslist) fo
   "browserslist": ["last 1 versions", "not ie <= 8"],
 }
 ```
+
+```js
+// Rule configuration (.eslintrc.json)
+{
+  // ...
+  "rules": [
+    "compat/compat": ["error", "defaults, not ie < 9"],
+  ]
+}
 
 ```js
 // Use development and production configurations (package.json)

--- a/src/Versioning.js
+++ b/src/Versioning.js
@@ -14,7 +14,7 @@ type TargetListItem = {
 export default function DetermineTargetsFromConfig(
   config?: BrowserListConfig
 ): Array<string> {
-  if (Array.isArray(config)) {
+  if (Array.isArray(config) || typeof config === 'string') {
     return browserslist(config);
   }
 

--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -39,7 +39,9 @@ export default {
     // Determine lowest targets from browserslist config, which reads user's
     // package.json config section. Use config from eslintrc for testing purposes
     const browserslistConfig: BrowserListConfig =
-      context.settings.browsers || context.settings.targets || context.options[0];
+      context.settings.browsers ||
+      context.settings.targets ||
+      context.options[0];
 
     const browserslistTargets = Versioning(
       DetermineTargetsFromConfig(browserslistConfig)

--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -39,7 +39,7 @@ export default {
     // Determine lowest targets from browserslist config, which reads user's
     // package.json config section. Use config from eslintrc for testing purposes
     const browserslistConfig: BrowserListConfig =
-      context.settings.browsers || context.settings.targets;
+      context.settings.browsers || context.settings.targets || context.options[0];
 
     const browserslistTargets = Versioning(
       DetermineTargetsFromConfig(browserslistConfig)

--- a/test/Versioning.spec.js
+++ b/test/Versioning.spec.js
@@ -41,4 +41,10 @@ describe('Versioning', () => {
     ];
     expect(Versioning(versions)).toMatchSnapshot();
   });
+
+  it('should support string config in rule option', () => {
+    const config = DetermineTargetsFromConfig('defaults, not ie < 9');
+    const result = Versioning(config);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/test/__snapshots__/Versioning.spec.js.snap
+++ b/test/__snapshots__/Versioning.spec.js.snap
@@ -234,3 +234,93 @@ Object {
   },
 }
 `;
+
+exports[`Versioning should support string config in rule option 1`] = `
+Array [
+  Object {
+    "parsedVersion": 4,
+    "target": "samsung",
+    "version": "4",
+  },
+  Object {
+    "parsedVersion": 11.1,
+    "target": "safari",
+    "version": "11.1",
+  },
+  Object {
+    "parsedVersion": 57,
+    "target": "opera",
+    "version": "57",
+  },
+  Object {
+    "parsedVersion": 46,
+    "target": "op_mob",
+    "version": "46",
+  },
+  Object {
+    "parsedVersion": 0,
+    "target": "op_mini",
+    "version": "all",
+  },
+  Object {
+    "parsedVersion": 11.3,
+    "target": "ios_saf",
+    "version": "11.3-11.4",
+  },
+  Object {
+    "parsedVersion": 11,
+    "target": "ie_mob",
+    "version": "11",
+  },
+  Object {
+    "parsedVersion": 11,
+    "target": "ie",
+    "version": "11",
+  },
+  Object {
+    "parsedVersion": 60,
+    "target": "firefox",
+    "version": "60",
+  },
+  Object {
+    "parsedVersion": 17,
+    "target": "edge",
+    "version": "17",
+  },
+  Object {
+    "parsedVersion": 71,
+    "target": "chrome",
+    "version": "71",
+  },
+  Object {
+    "parsedVersion": 7.12,
+    "target": "baidu",
+    "version": "7.12",
+  },
+  Object {
+    "parsedVersion": 4.4,
+    "target": "android",
+    "version": "4.4.3-4.4.4",
+  },
+  Object {
+    "parsedVersion": 11.8,
+    "target": "and_uc",
+    "version": "11.8",
+  },
+  Object {
+    "parsedVersion": 1.2,
+    "target": "and_qq",
+    "version": "1.2",
+  },
+  Object {
+    "parsedVersion": 64,
+    "target": "and_ff",
+    "version": "64",
+  },
+  Object {
+    "parsedVersion": 71,
+    "target": "and_chr",
+    "version": "71",
+  },
+]
+`;


### PR DESCRIPTION
I've totally messed up my repository, therefore i started a repository and pull request. This makes #121 obsolete

This adds the possibility to specify browserlist as rule configuration in eslint e.g.
```js
{
  // ...
  "rules": [
    "compat/compat": ["error", "defaults, not ie < 9"],
  ]
}
```