### PR TITLE
support detecting locally defined polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ eslint-plugin-compat
 [![NPM version](https://badge.fury.io/js/eslint-plugin-compat.svg)](http://badge.fury.io/js/eslint-plugin-compat)
 [![Dependency Status](https://img.shields.io/david/amilajack/eslint-plugin-compat.svg)](https://david-dm.org/amilajack/eslint-plugin-compat)
 [![npm](https://img.shields.io/npm/dm/eslint-plugin-compat.svg)](https://npm-stat.com/charts.html?package=eslint-plugin-compat)
+[![Backers on Open Collective](https://opencollective.com/eslint-plugin-compat/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/eslint-plugin-compat/sponsors/badge.svg)](#sponsors)
 
 Lint the browser compatibility of your code
 

--- a/package.json
+++ b/package.json
@@ -71,5 +71,10 @@
   "engines": {
     "node": ">=8.x",
     "npm": ">=6.8.0"
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/eslint-plugin-compat",
+    "logo": "https://opencollective.com/opencollective/logo.txt"
   }
 }

--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -95,11 +95,19 @@ export default {
         if (node.parent) {
           const { type } = node.parent;
           if (
+            // ex. const { Set } = require('immutable');
+            type === 'Property' ||
+            // ex. function Set() {}
             type === 'FunctionDeclaration' ||
+            // ex. const Set = () => {}
             type === 'VariableDeclarator' ||
+            // ex. class Set {}
             type === 'ClassDeclaration' ||
+            // ex. import Set from 'set';
             type === 'ImportDefaultSpecifier' ||
+            // ex. import {Set} from 'set';
             type === 'ImportSpecifier' ||
+            // ex. import {Set} from 'set';
             type === 'ImportDeclaration'
           ) {
             identifiers.add(node.name);

--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -17,6 +17,22 @@ type Context = {
   report: () => void
 };
 
+function getName(node) {
+  switch (node.type) {
+    case 'NewExpression': {
+      return node.callee.name;
+    }
+    case 'MemberExpression': {
+      return node.object.name;
+    }
+    case 'CallExpression': {
+      return node.callee.name;
+    }
+    default:
+      throw new Error('not found');
+  }
+}
+
 export type BrowserListConfig =
   | Array<string>
   | {
@@ -47,6 +63,8 @@ export default {
       DetermineTargetsFromConfig(browserslistConfig)
     );
 
+    const errors = [];
+
     function lint(node: ESLintNode) {
       const { isValid, rule, unsupportedTargets } = Lint(
         node,
@@ -55,7 +73,7 @@ export default {
       );
 
       if (!isValid) {
-        context.report({
+        errors.push({
           node,
           message: [
             generateErrorName(rule),
@@ -66,14 +84,35 @@ export default {
       }
     }
 
+    const identifiers = new Set();
+
     return {
-      // HACK: Ideally, rules will be generated at runtime. Each rule will have
-      //       have the ability to register itself to run on specific AST
-      //       nodes. For now, we're using the `CallExpression` node since
-      //       its what most rules will run on
       CallExpression: lint,
       MemberExpression: lint,
-      NewExpression: lint
+      NewExpression: lint,
+      // Keep track of all the defined variables. Do not report errors for nodes that are not defined
+      Identifier(node) {
+        if (node.parent) {
+          const { type } = node.parent;
+          if (
+            type === 'FunctionDeclaration' ||
+            type === 'VariableDeclarator' ||
+            type === 'ClassDeclaration' ||
+            type === 'ImportDefaultSpecifier' ||
+            type === 'ImportSpecifier' ||
+            type === 'ImportDeclaration'
+          ) {
+            identifiers.add(node.name);
+          }
+        }
+      },
+      'Program:exit': () => {
+        // Get a map of all the variables defined in the root scope (not the global scope)
+        // const variablesMap = context.getScope().childScopes.map(e => e.set)[0];
+        errors
+          .filter(error => !identifiers.has(getName(error.node)))
+          .forEach(node => context.report(node));
+      }
     };
   }
 };

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -17,6 +17,29 @@ ruleTester.run('compat', rule, {
     },
     {
       code: `
+        const { Set } = require('immutable');
+        new Set();
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        const Set = require('immutable').Set;
+        new Set();
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        const { Set } = require('immutable');
+        (() => {
+          new Set();
+        })();
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
         import Set from 'immutable';
         new Set();
       `,

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -3,11 +3,75 @@ import { RuleTester } from 'eslint';
 import rule from '../src/rules/compat';
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2015 }
+  parserOptions: { ecmaVersion: 2015, sourceType: 'module' }
 });
 
 ruleTester.run('compat', rule, {
   valid: [
+    {
+      code: `
+        import { Set } from 'immutable';
+        new Set();
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        import Set from 'immutable';
+        new Set();
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        function Set() {}
+        new Set();
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        const Set = () => {};
+        new Set();
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        const bar = () => {
+          const Set = () => {};
+          new Set();
+        }
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        const bar = () => {
+          class Set {}
+          new Set()
+        }
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        const bar = () => {
+          const Set = {}
+          new Set()
+        }
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
+    {
+      code: `
+        const bar = () => {
+          function Set() {}
+          new Set()
+        }
+      `,
+      settings: { browsers: ['ie 9'] }
+    },
     {
       code: 'document.documentElement()',
       settings: { browsers: ['Safari 11', 'Opera 57', 'Edge 17'] }
@@ -70,6 +134,29 @@ ruleTester.run('compat', rule, {
     }
   ],
   invalid: [
+    {
+      code: `
+        import { Map } from 'immutable';
+        new Set()
+      `,
+      settings: { browsers: ['ie 9'] },
+      errors: [
+        {
+          message: 'Set is not supported in IE 9',
+          type: 'NewExpression'
+        }
+      ]
+    },
+    {
+      code: 'new Set()',
+      settings: { browsers: ['ie 9'] },
+      errors: [
+        {
+          message: 'Set is not supported in IE 9',
+          type: 'NewExpression'
+        }
+      ]
+    },
     {
       code: 'new TypedArray()',
       settings: { browsers: ['ie 9'] },


### PR DESCRIPTION
This PR recognizes locally defined polyfills by users and doesn't throw errors in those cases.

This is an error (when targeting IE):
```js
const a = new Set();
```

This PR allows the above to not be an error:
```js
class Set {} // A user defined polyfill
const a = new Set();
```

This PR does **not** handle the following cases, which will be addressed in later PR's:
```js
const n = navigator; // navigator is supported
n.serviceWorker // navigator.serviceWorker is supported and should throw
```
- [x] add open collective info to readme
- [x] allow users to locally define polyfills
- [x] add corresponding test cases

Fixes https://github.com/amilajack/eslint-plugin-compat/issues/192
Closes https://github.com/amilajack/eslint-plugin-compat/issues/195