### PR TITLE
allow custom user records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.2.0
+### Added
+- Support adding custom compatibility records
+
 ## v3.1.0
 ### Added
 - Support detecting locally defined polyfills (#207)  bb3be6e

--- a/src/LintTypes.js
+++ b/src/LintTypes.js
@@ -27,22 +27,34 @@ export type ESLintNode = {
   }
 } & node;
 
+export type TargetListItem = {
+  target: string,
+  parsedVersion: number,
+  version: string | 'all'
+};
+
 export type Node = {
   astNodeType: string,
   id: string,
+  caniuseId: string,
+  protoChain: string[],
+  protoChainId: string,
   object: string,
   property?: string,
   name?: string,
-  getUnsupportedTargets: (node: Node, targets: Targets) => Array<string>,
-  isValid: (
+  getUnsupportedTargets: (
+    node: Node,
+    targets: Array<TargetListItem>
+  ) => Array<string>,
+  recordMatchesNode: (
     node: Node,
     eslintNode: ESLintNode,
-    targets: Array<string>
+    targets: Array<TargetListItem>
   ) => boolean
 };
 
-export type isValidObject = {
+export type RecordMatchesNode = {
   rule: Node,
-  isValid: boolean,
+  recordMatchesNode: boolean,
   unsupportedTargets: Array<string>
 };

--- a/src/Versioning.js
+++ b/src/Versioning.js
@@ -1,12 +1,7 @@
 // @flow
 import browserslist from 'browserslist';
 import type { BrowserListConfig } from './rules/compat';
-
-type TargetListItem = {
-  target: string,
-  parsedVersion: number,
-  version: string | 'all'
-};
+import type { TargetListItem } from './LintTypes';
 
 /**
  * Determine the targets based on the browserslist config object

--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -102,7 +102,7 @@ export function getUnsupportedTargets(
 /**
  * Check if the node has matching object or properties
  */
-function isValid(
+function recordMatchesNode(
   node: Node,
   eslintNode: ESLintNode,
   targets: Targets
@@ -128,6 +128,8 @@ function isValid(
       return true;
   }
 
+  // Return true if no unsupported targets exist, meaning all targets are
+  // supported
   return !getUnsupportedTargets(node, targets).length;
 }
 
@@ -160,7 +162,7 @@ const MdnProvider: Array<Node> = AstMetadata
   // Add rule and target support logic for each entry
   .map(rule => ({
     ...rule,
-    isValid,
+    recordMatchesNode,
     getUnsupportedTargets
   }));
 

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -4,4 +4,4 @@ import Mdn from './MdnProvider';
 import type { Node } from '../LintTypes';
 
 // eslint-disable-next-line import/prefer-default-export
-export const rules: Array<Node> = [...CanIUse, ...Mdn];
+export default ([...CanIUse, ...Mdn]: Array<Node>);

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -9,6 +9,30 @@ const ruleTester = new RuleTester({
 ruleTester.run('compat', rule, {
   valid: [
     {
+      code: 'foo.bar()',
+      settings: {
+        polyfills: ['foo.bar'],
+        browsers: ['ie 10'],
+        records: [
+          {
+            name: 'foo.bar',
+            id: 'foo.bar',
+            astNodeType: 'MemberExpression',
+            protoChain: ['foo', 'bar'],
+            protoChainId: 'foo.bar',
+            object: 'foo',
+            property: 'bar',
+            recordMatchesNode() {
+              return false;
+            },
+            getUnsupportedTargets() {
+              return ['IE 10'];
+            }
+          }
+        ]
+      }
+    },
+    {
       code: `
         import { Set } from 'immutable';
         new Set();

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -158,6 +158,34 @@ ruleTester.run('compat', rule, {
   ],
   invalid: [
     {
+      code: 'foo.bar()',
+      settings: {
+        browsers: ['ie 10'],
+        records: [
+          {
+            name: 'foo.bar',
+            id: 'foo.bar',
+            astNodeType: 'MemberExpression',
+            protoChain: ['foo', 'bar'],
+            protoChainId: 'foo.bar',
+            object: 'foo',
+            property: 'bar',
+            recordMatchesNode() {
+              return false;
+            },
+            getUnsupportedTargets() {
+              return ['IE 10'];
+            }
+          }
+        ]
+      },
+      errors: [
+        {
+          message: 'foo.bar is not supported in IE 10'
+        }
+      ]
+    },
+    {
       code: 'location.origin',
       settings: { browsers: ['ie 10'] },
       errors: [


### PR DESCRIPTION
## Summary

This PR allows users to define custom compatibility records. This is useful for adding compatibility checks for APIs that are not supported by this plugin.

Docs: https://github.com/amilajack/eslint-plugin-compat/wiki/Custom-Compatibility-Records

### Example Usage:

Code:
```js
foo.bar();
```
Eslint Config
```jsonc
// .eslintrc.json
{
  settings: {
    browsers: ['ie 10'],
    records: [
      {
        name: 'foo.bar',
        id: 'foo.bar',
        astNodeType: 'MemberExpression',
        protoChain: ['foo', 'bar'],
        protoChainId: 'foo.bar',
        object: 'foo',
        property: 'bar',
        recordMatchesNode() {
          return false;
        },
        getUnsupportedTargets() {
          return ['IE 10'];
        }
      }
    ]
  },
}
```

Closes https://github.com/amilajack/eslint-plugin-compat/issues/90

- [x] add e2e tests
- [x] update `CHANGELOG.md`
- [x] add docs for adding custom compat records