### PR TITLE
relative browsers config lookup

### DIFF
--- a/src/Versioning.js
+++ b/src/Versioning.js
@@ -10,22 +10,27 @@ type TargetListItem = {
 
 /**
  * Determine the targets based on the browserslist config object
+ *
+ * @param configPath - The file or a directory path to look for the browserslist config file
  */
 export default function DetermineTargetsFromConfig(
+  configPath: string,
   config?: BrowserListConfig
 ): Array<string> {
+  const browserslistOpts = { path: configPath };
+
   if (Array.isArray(config) || typeof config === 'string') {
-    return browserslist(config);
+    return browserslist(config, browserslistOpts);
   }
 
   if (config && typeof config === 'object') {
-    return browserslist([
-      ...(config.production || []),
-      ...(config.development || [])
-    ]);
+    return browserslist(
+      [...(config.production || []), ...(config.development || [])],
+      browserslistOpts
+    );
   }
 
-  return browserslist();
+  return browserslist(undefined, browserslistOpts);
 }
 
 /**

--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -60,7 +60,7 @@ export default {
       context.options[0];
 
     const browserslistTargets = Versioning(
-      DetermineTargetsFromConfig(browserslistConfig)
+      DetermineTargetsFromConfig(context.getFilename(), browserslistConfig)
     );
 
     const errors = [];

--- a/test/CanIUseProvider.spec.js
+++ b/test/CanIUseProvider.spec.js
@@ -5,7 +5,10 @@ import expectRangeResultJSON from './expect-range-result-config.json';
 describe('CanIUseProvider', () => {
   it('should return unsupported ios targets with range value for Fetch API', () => {
     const node = { caniuseId: 'fetch' };
-    const config = DetermineTargetsFromConfig(expectRangeResultJSON.browsers);
+    const config = DetermineTargetsFromConfig(
+      '.',
+      expectRangeResultJSON.browsers
+    );
     const targets = Versioning(config);
     const result = getUnsupportedTargets(node, targets);
     expect(result).toMatchSnapshot();

--- a/test/Versioning.spec.js
+++ b/test/Versioning.spec.js
@@ -5,13 +5,17 @@ import singleVersionEnvPackageJSON from './single-version-config.package.json';
 
 describe('Versioning', () => {
   it('should support multi env config in browserslist package.json', () => {
-    const config = DetermineTargetsFromConfig(multiEnvPackageJSON.browsers);
+    const config = DetermineTargetsFromConfig(
+      '.',
+      multiEnvPackageJSON.browsers
+    );
     const result = Versioning(config);
     expect(result).toMatchSnapshot();
   });
 
   it('should support single array config in browserslist package.json', () => {
     const config = DetermineTargetsFromConfig(
+      '.',
       singleArrayEnvPackageJSON.browsers
     );
     const result = Versioning(config);
@@ -20,6 +24,7 @@ describe('Versioning', () => {
 
   it('should support single version config in browserslist package.json', () => {
     const config = DetermineTargetsFromConfig(
+      '.',
       singleVersionEnvPackageJSON.browsers
     );
     const result = Versioning(config);
@@ -43,7 +48,7 @@ describe('Versioning', () => {
   });
 
   it('should support string config in rule option', () => {
-    const config = DetermineTargetsFromConfig('defaults, not ie < 9');
+    const config = DetermineTargetsFromConfig('.', 'defaults, not ie < 9');
     const result = Versioning(config);
     expect(result).toMatchSnapshot();
   });


### PR DESCRIPTION
Closes https://github.com/amilajack/eslint-plugin-compat/issues/42

This allows the plugin to run correctly despite being called from a cwd that is not the root of the project.