### PR TITLE
Change npm engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "engines": {
     "node": ">=8.x",
-    "npm": ">=6.8.0"
+    "npm": ">=6.x"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
According to https://nodejs.org/en/download/releases/, NodeJs 8 uses NPM 6.4.1 and only NodeJs could use NPM 6.8If we use NodeJs 11 (and so NPM 6.7) and we have the flag engine-strict to true, we could not download it, because the specified version is too recent.We should add some flexibility on this engine version