### PR TITLE
Optimize loop in lint()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.3.0
+### Performance
+- Optimize core loop to run ~50% faster ([https://github.com/amilajack/eslint-plugin-compat/pull/245](https://github.com/amilajack/eslint-plugin-compat/pull/245))
+
 ## v3.2.0
 ### Added
 - Support for `eslint@6`

--- a/src/Lint.js
+++ b/src/Lint.js
@@ -1,6 +1,6 @@
 // @flow
 import { rules } from './providers';
-import type { Node, ESLintNode, Targets, isValidObject } from './LintTypes';
+import type { Node, ESLintNode, Targets, lintResultObject } from './LintTypes';
 
 export function generateErrorName(_node: Node): string {
   if (_node.name) return _node.name;
@@ -18,7 +18,7 @@ export default function Lint(
   eslintNode: ESLintNode,
   targets: Targets = ['chrome', 'firefox', 'safari', 'edge'],
   polyfills: Set<string>
-): isValidObject {
+): ?lintResultObject {
   // Find the corresponding rules for a eslintNode by it's astNodeType
   const failingRule = rules
     .filter(
@@ -38,15 +38,10 @@ export default function Lint(
   return failingRule
     ? {
         rule: failingRule,
-        isValid: false,
         unsupportedTargets: failingRule.getUnsupportedTargets(
           failingRule,
           targets
         )
       }
-    : {
-        rule: {},
-        unsupportedTargets: [],
-        isValid: true
-      };
+    : null;
 }

--- a/src/Lint.js
+++ b/src/Lint.js
@@ -20,20 +20,19 @@ export default function Lint(
   polyfills: Set<string>
 ): ?lintResultObject {
   // Find the corresponding rules for a eslintNode by it's astNodeType
-  const failingRule = rules
-    .filter(
-      (rule: Node): boolean =>
-        rule.astNodeType === eslintNode.type &&
-        // v2 allowed users to select polyfills based off their caniuseId. This is
-        // no longer supported. Keeping this here to avoid breaking changes.
-        !polyfills.has(rule.id) &&
-        // Check if polyfill is provided (ex. `Promise.all`)
-        !polyfills.has(rule.protoChainId) &&
-        // Check if entire API is polyfilled (ex. `Promise`)
-        !polyfills.has(rule.protoChain[0])
-    )
-    // Find the first failing rule
-    .find((rule: Node): boolean => !rule.isValid(rule, eslintNode, targets));
+  const failingRule = rules.find(
+    (rule: Node): boolean =>
+      rule.astNodeType === eslintNode.type &&
+      // Check that the rule fails for this node (unless there's a polyfill)
+      !rule.isValid(rule, eslintNode, targets) &&
+      // v2 allowed users to select polyfills based off their caniuseId. This is
+      // no longer supported. Keeping this here to avoid breaking changes.
+      !polyfills.has(rule.id) &&
+      // Check if polyfill is provided (ex. `Promise.all`)
+      !polyfills.has(rule.protoChainId) &&
+      // Check if entire API is polyfilled (ex. `Promise`)
+      !polyfills.has(rule.protoChain[0])
+  );
 
   return failingRule
     ? {

--- a/src/LintTypes.js
+++ b/src/LintTypes.js
@@ -49,8 +49,7 @@ export type Node = {
   ) => boolean
 };
 
-export type isValidObject = {
+export type lintResultObject = {
   rule: Node,
-  isValid: boolean,
   unsupportedTargets: Array<string>
 };

--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -60,22 +60,23 @@ export default {
     const errors = [];
 
     function lint(node: ESLintNode) {
-      const { isValid, rule, unsupportedTargets } = Lint(
+      const lintResult = Lint(
         node,
         browserslistTargets,
         new Set(context.settings.polyfills || [])
       );
 
-      if (!isValid) {
-        errors.push({
-          node,
-          message: [
-            generateErrorName(rule),
-            'is not supported in',
-            unsupportedTargets.join(', ')
-          ].join(' ')
-        });
-      }
+      if (lintResult == null) return;
+
+      const { rule, unsupportedTargets } = lintResult;
+      errors.push({
+        node,
+        message: [
+          generateErrorName(rule),
+          'is not supported in',
+          unsupportedTargets.join(', ')
+        ].join(' ')
+      });
     }
 
     const identifiers = new Set();


### PR DESCRIPTION
Re: https://github.com/amilajack/eslint-plugin-compat/issues/193

@amilajack I took a look at the performance here, and found that a surprising amount of the cost of the `lint()` function is coming from those `polyfills.has()` lookups, even when `polyfills` is a very small set (the project I tested this change against has only 3). So the main optimization here is:

## Before

* `filter` rules down to those that aren't polyfilled
* Run remaining rules through `rule.isValid()`

## After

* Make a single pass through the rules instead of using a separate `filter` step
* Check `rule.isValid()` before checking for polyfills

This simple change cut the time it takes to run `compat/compat` against my project by more than half, from ~13s to ~5.5s! 😮