### PR TITLE
Pre-filter and sort rules for 400% perf boost

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/node_modules/fbjs/.*
+.*/node_modules/lodash.memoize/.*
 .*/node_modules/*
 .*/git/.*
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ast-metadata-inferer": "^0.1.1",
     "browserslist": "^4.6.3",
     "caniuse-db": "^1.0.30000977",
+    "lodash.memoize": "4.1.2",
     "mdn-browser-compat-data": "^0.0.84",
     "semver": "^6.1.2"
   },

--- a/src/Lint.js
+++ b/src/Lint.js
@@ -1,37 +1,40 @@
 // @flow
-import type { Node, ESLintNode, lintResultObject } from './LintTypes';
+import type { Node, ESLintNode } from './LintTypes';
 
-export function generateErrorName(_node: Node): string {
-  if (_node.name) return _node.name;
-  if (_node.property) return `${_node.object}.${_node.property}()`;
-  return _node.object;
+export function lintCallExpression(
+  reporter: Function,
+  rules: Array<Node>,
+  node: ESLintNode
+) {
+  if (!node.callee) return;
+  const calleeName = node.callee.name;
+  const failingRule = rules.find(rule => rule.object === calleeName);
+  if (failingRule) reporter(failingRule, node);
 }
 
-/**
- * Return false if a if a rule fails
- *
- * TODO: Eventually, targets will default to 'modern', ('chrome@50', safari@8)
- *       See https://github.com/amilajack/eslint-plugin-compat/wiki#release-200
- */
-export default function Lint(
-  eslintNode: ESLintNode,
-  rulesForCurrentTargets,
-  polyfills: Set<string>
-): ?lintResultObject {
-  // Find the corresponding rules for a eslintNode by it's astNodeType
-  const failingRule = rulesForCurrentTargets.find(
-    (rule: Node): boolean =>
-      rule.astNodeType === eslintNode.type &&
-      // Check that the rule fails for this node (unless there's a polyfill)
-      !rule.isValid(rule, eslintNode) &&
-      // v2 allowed users to select polyfills based off their caniuseId. This is
-      // no longer supported. Keeping this here to avoid breaking changes.
-      !polyfills.has(rule.id) &&
-      // Check if polyfill is provided (ex. `Promise.all`)
-      !polyfills.has(rule.protoChainId) &&
-      // Check if entire API is polyfilled (ex. `Promise`)
-      !polyfills.has(rule.protoChain[0])
-  );
+export function lintNewExpression(
+  reporter: Function,
+  rules: Array<Node>,
+  node: ESLintNode
+) {
+  if (!node.callee) return;
+  const calleeName = node.callee.name;
+  const failingRule = rules.find(rule => rule.object === calleeName);
+  if (failingRule) reporter(failingRule, node);
+}
 
-  return failingRule;
+export function lintMemberExpression(
+  reporter: Function,
+  rules: Array<Node>,
+  node: ESLintNode
+) {
+  if (!node.object || !node.property) return;
+  const objectName = node.object.name;
+  const propertyName = node.property.name;
+  const failingRule = rules.find(
+    rule =>
+      rule.object === objectName &&
+      (rule.property == null || rule.property === propertyName)
+  );
+  if (failingRule) reporter(failingRule, node);
 }

--- a/src/Lint.js
+++ b/src/Lint.js
@@ -1,6 +1,5 @@
 // @flow
-import { rules } from './providers';
-import type { Node, ESLintNode, Targets, lintResultObject } from './LintTypes';
+import type { Node, ESLintNode, lintResultObject } from './LintTypes';
 
 export function generateErrorName(_node: Node): string {
   if (_node.name) return _node.name;
@@ -16,15 +15,15 @@ export function generateErrorName(_node: Node): string {
  */
 export default function Lint(
   eslintNode: ESLintNode,
-  targets: Targets = ['chrome', 'firefox', 'safari', 'edge'],
+  rulesForCurrentTargets,
   polyfills: Set<string>
 ): ?lintResultObject {
   // Find the corresponding rules for a eslintNode by it's astNodeType
-  const failingRule = rules.find(
+  const failingRule = rulesForCurrentTargets.find(
     (rule: Node): boolean =>
       rule.astNodeType === eslintNode.type &&
       // Check that the rule fails for this node (unless there's a polyfill)
-      !rule.isValid(rule, eslintNode, targets) &&
+      !rule.isValid(rule, eslintNode) &&
       // v2 allowed users to select polyfills based off their caniuseId. This is
       // no longer supported. Keeping this here to avoid breaking changes.
       !polyfills.has(rule.id) &&
@@ -34,13 +33,5 @@ export default function Lint(
       !polyfills.has(rule.protoChain[0])
   );
 
-  return failingRule
-    ? {
-        rule: failingRule,
-        unsupportedTargets: failingRule.getUnsupportedTargets(
-          failingRule,
-          targets
-        )
-      }
-    : null;
+  return failingRule;
 }

--- a/src/LintTypes.js
+++ b/src/LintTypes.js
@@ -25,6 +25,7 @@ export type Targets = Array<string>;
 
 export type ESLintNode = {
   object?: node,
+  parent?: ESLintNode,
   property?: node,
   callee?: {
     name?: string,

--- a/src/LintTypes.js
+++ b/src/LintTypes.js
@@ -42,15 +42,7 @@ export type Node = {
   object: string,
   property?: string,
   name?: string,
-  getUnsupportedTargets: (node: Node, targets: Targets) => Array<string>,
-  isValid: (
-    node: Node,
-    eslintNode: ESLintNode,
-    targets: Array<string>
-  ) => boolean
-};
-
-export type lintResultObject = {
-  rule: Node,
-  unsupportedTargets: Array<string>
+  protoChainId: string,
+  protoChain: Array<string>,
+  getUnsupportedTargets: (node: Node, targets: Targets) => Array<string>
 };

--- a/src/providers/CanIUseProvider.js
+++ b/src/providers/CanIUseProvider.js
@@ -1,7 +1,7 @@
 // @flow
 // $FlowFixMe: Flow import error
 import caniuseRecords from 'caniuse-db/fulldata-json/data-2.0.json';
-import type { Node, ESLintNode, Targets, Target } from '../LintTypes';
+import type { Node, Targets, Target } from '../LintTypes';
 
 type TargetMetadata = {
   // The list of targets supported by the provider
@@ -114,34 +114,6 @@ export function getUnsupportedTargets(
   return targets
     .filter(target => canIUseIsNotSupported(node, target))
     .map(formatTargetNames);
-}
-
-/**
- * Check if the node has matching object or properties
- */
-function isValid(node: Node, eslintNode: ESLintNode): boolean {
-  switch (eslintNode.type) {
-    case 'CallExpression':
-    case 'NewExpression':
-      if (!eslintNode.callee) return true;
-      if (eslintNode.callee.name !== node.object) return true;
-      break;
-    case 'MemberExpression':
-      // Pass tests if non-matching object or property
-      if (!eslintNode.object || !eslintNode.property) return true;
-      if (eslintNode.object.name !== node.object) return true;
-
-      // If the property is missing from the rule, it means that only the
-      // object is required to determine compatibility
-      if (!node.property) break;
-
-      if (eslintNode.property.name !== node.property) return true;
-      break;
-    default:
-      return true;
-  }
-
-  return false;
 }
 
 const CanIUseProvider: Array<Node> = [
@@ -290,7 +262,6 @@ const CanIUseProvider: Array<Node> = [
   }
 ].map(rule =>
   Object.assign({}, rule, {
-    isValid,
     getUnsupportedTargets,
     id: rule.property ? `${rule.object}.${rule.property}` : rule.object,
     protoChainId: rule.property

--- a/src/providers/CanIUseProvider.js
+++ b/src/providers/CanIUseProvider.js
@@ -119,11 +119,7 @@ export function getUnsupportedTargets(
 /**
  * Check if the node has matching object or properties
  */
-function isValid(
-  node: Node,
-  eslintNode: ESLintNode,
-  targets: Targets
-): boolean {
+function isValid(node: Node, eslintNode: ESLintNode): boolean {
   switch (eslintNode.type) {
     case 'CallExpression':
     case 'NewExpression':
@@ -145,7 +141,7 @@ function isValid(
       return true;
   }
 
-  return !getUnsupportedTargets(node, targets).length;
+  return false;
 }
 
 const CanIUseProvider: Array<Node> = [

--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -1,6 +1,6 @@
 import AstMetadata from 'ast-metadata-inferer';
 import semver from 'semver';
-import type { Node, ESLintNode, Targets, Target } from '../LintTypes';
+import type { Node, Targets, Target } from '../LintTypes';
 
 type AstMetadataRecordType = {
   apiType: 'js-api' | 'css-api',
@@ -99,34 +99,6 @@ export function getUnsupportedTargets(
     .map(formatTargetNames);
 }
 
-/**
- * Check if the node has matching object or properties
- */
-function isValid(node: Node, eslintNode: ESLintNode): boolean {
-  switch (eslintNode.type) {
-    case 'CallExpression':
-    case 'NewExpression':
-      if (!eslintNode.callee) return true;
-      if (eslintNode.callee.name !== node.object) return true;
-      break;
-    case 'MemberExpression':
-      // Pass tests if non-matching object or property
-      if (!eslintNode.object || !eslintNode.property) return true;
-      if (eslintNode.object.name !== node.object) return true;
-
-      // If the property is missing from the rule, it means that only the
-      // object is required to determine compatibility
-      if (!node.property) break;
-
-      if (eslintNode.property.name !== node.property) return true;
-      break;
-    default:
-      return true;
-  }
-
-  return false;
-}
-
 function getMetadataName(metadata: Node) {
   switch (metadata.protoChain.length) {
     case 1: {
@@ -156,7 +128,6 @@ const MdnProvider: Array<Node> = AstMetadata
   // Add rule and target support logic for each entry
   .map(rule => ({
     ...rule,
-    isValid,
     getUnsupportedTargets
   }));
 

--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -102,11 +102,7 @@ export function getUnsupportedTargets(
 /**
  * Check if the node has matching object or properties
  */
-function isValid(
-  node: Node,
-  eslintNode: ESLintNode,
-  targets: Targets
-): boolean {
+function isValid(node: Node, eslintNode: ESLintNode): boolean {
   switch (eslintNode.type) {
     case 'CallExpression':
     case 'NewExpression':
@@ -128,7 +124,7 @@ function isValid(
       return true;
   }
 
-  return !getUnsupportedTargets(node, targets).length;
+  return false;
 }
 
 function getMetadataName(metadata: Node) {

--- a/test/__snapshots__/Versioning.spec.js.snap
+++ b/test/__snapshots__/Versioning.spec.js.snap
@@ -113,9 +113,9 @@ Array [
     "version": "67",
   },
   Object {
-    "parsedVersion": 74,
+    "parsedVersion": 75,
     "target": "and_chr",
-    "version": "74",
+    "version": "75",
   },
 ]
 `;
@@ -223,9 +223,9 @@ Array [
     "version": "67",
   },
   Object {
-    "parsedVersion": 74,
+    "parsedVersion": 75,
     "target": "and_chr",
-    "version": "74",
+    "version": "75",
   },
 ]
 `;
@@ -323,9 +323,9 @@ Array [
     "version": "67",
   },
   Object {
-    "parsedVersion": 74,
+    "parsedVersion": 75,
     "target": "and_chr",
-    "version": "74",
+    "version": "75",
   },
 ]
 `;
@@ -443,9 +443,9 @@ Array [
     "version": "67",
   },
   Object {
-    "parsedVersion": 74,
+    "parsedVersion": 75,
     "target": "and_chr",
-    "version": "74",
+    "version": "75",
   },
 ]
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,14 +1402,14 @@ camelcase@^5.0.0:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-db@^1.0.30000977:
-  version "1.0.30000977"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000977.tgz#8ee0141e26443941ae02e06826357bf4ee847541"
-  integrity sha512-V+FisJLGKnEZg7Dmc1QxKEM62LJKOYIF8xEFCg9N98nCdac1gBZioxtYOXcscZtKwsoLcwyA+YFrgIMZ43ENfA==
+  version "1.0.30000979"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000979.tgz#b7118599641412a3a18b32f0d8ea77735235a360"
+  integrity sha512-UESBHOfR0IiQK14I0Cg+FKgPHgcnuHTagX67K5Tn+c0/MhrUniUUH4FNJcoohVpGjRW7+C2mUuAJpZ44jGKVVQ==
 
 caniuse-lite@^1.0.30000975:
-  version "1.0.30000977"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000977.tgz#7da2ca14cae2fddb368c05c57ab4a529afd658ff"
-  integrity sha512-RTXL32vdfAc2g9aoDL6vnBzbOO/3sM+T+YX4m7W9iFZnl3qIz7WYoZZpcZpALud8xq4+N56rnruX/NQy9HQu6A==
+  version "1.0.30000979"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000979.tgz#92f16d00186a6cf20d6c5711bb6e042a3d667029"
+  integrity sha512-gcu45yfq3B7Y+WB05fOMfr0EiSlq+1u+m6rPHyJli/Wy3PVQNGaU7VA4bZE5qw+AU2UVOBR/N5g1bzADUqdvFw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1950,9 +1950,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.164:
-  version "1.3.173"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.173.tgz#275b9ba235447b95fc3204d32ca2c5a8bf2ca599"
-  integrity sha512-weH16m8as+4Fy4XJxrn/nFXsIqB7zkxERhvj/5YX2HE4HB8MCu98Wsef4E3mu0krIT27ic0bGsr+TvqYrUn6Qg==
+  version "1.3.180"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.180.tgz#8e8c6be930d137e88cf2946ad2ec6521d24ba70e"
+  integrity sha512-jwI82/63GeH7f08IR+4v/tbGM4DMAApMZO0SXLcC0np4lcqWjQBl0MIHkfXEqesLc55+NhVVX8g7eFlamEWoNQ==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -2747,9 +2747,9 @@ got@^8.3.2:
     url-to-options "^1.0.1"
 
 graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
+  integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -2917,9 +2917,9 @@ ignore@^4.0.6:
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 import-fresh@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
-  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
+  integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -3870,6 +3870,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash.memoize@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -4206,9 +4211,9 @@ node-pre-gyp@^0.12.0:
     tar "^4"
 
 node-releases@^1.1.23:
-  version "1.1.23"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
-  integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
+  version "1.1.24"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.24.tgz#2fb494562705c01bfb81a7af9f8584c4d56311b4"
+  integrity sha512-wym2jptfuKowMmkZsfCSTsn8qAVo8zm+UiQA6l5dNqUcpfChZSnS/vbbpOeXczf+VdPhutxh+99lWHhdd6xKzg==
   dependencies:
     semver "^5.3.0"
 
@@ -4265,9 +4270,9 @@ npm-conf@^1.1.0:
     pify "^3.0.0"
 
 npm-packlist@^1.1.6:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
-  integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.4.tgz#866224233850ac534b63d1a6e76050092b5d2f44"
+  integrity sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -5179,9 +5184,9 @@ seek-bzip@^1.0.5:
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.2.tgz#079960381376a3db62eb2edc8a3bfb10c7cfe318"
-  integrity sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ==
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.3.tgz#ef997a1a024f67dd48a7f155df88bb7b5c6c3fc7"
+  integrity sha512-aymF+56WJJMyXQHcd4hlK4N75rwj5RQpfW8ePlQnJsTYOBLlLbcIErR/G1s9SkIvKBqOudR3KAx4wEqP+F1hNQ==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Closes https://github.com/amilajack/eslint-plugin-compat/issues/193

Currently, the `Lint()` function loops through all 4361 rules on every node. The cost of all that looping really adds up! For most projects, most of those rules are irrelevant because they only fail for very old or esoteric browsers. In the project I used to test this branch, the browser list is

```
[
  'last 3 chrome version',
  'last 3 firefox version',
  'last 2 edge version',
  'last 2 safari version',
  'IE 11'
]
```

and only 1679 of the rules potentially fail. For a project that only supports modern browsers (no IE11), the relevant set of rules would be much smaller.

This PR filters the set of rules based on the targeted browser list, removing the need to iterate through irrelevant rules on every node. It does that filtering only once per browser list. This change reduces the time it takes to run `compat/compat` against my test project from ~5.5s to ~2.5s. 🚀 

---

I've marked this as WIP because the code here is very messy, so please take it as a proof of concept. If you like this change, let me know and I'll tidy it up!