### PR TITLE
Add schema to support browserlist as a second paramenter in eslintrc

### DIFF
--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -89,7 +89,7 @@ export default {
       recommended: true
     },
     fixable: 'code',
-    schema: []
+    schema: [{ type: 'string' }]
   },
   create(context: Context): ESLint {
     // Determine lowest targets from browserslist config, which reads user's


### PR DESCRIPTION
The rule schema is empty. This disallows using the second parameter in .eslintrc.json as browserconfig.

Because of that this rule errors with
```
Configuration for rule "compat/compat" is invalid: Value ["last 1 version, last 1 firefox version, last 1 edge version, ie 11, not safari < 12"] should NOT have more than 0 items.
```

when it should accept it as an option.

This causes an issue for our plugin that relies on your plugin: https://github.com/forcedotcom/eslint-plugin-aura/pull/4