### PR TITLE
fix: support safari TP as a target

### DIFF
--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -87,10 +87,14 @@ export function mdnSupported(node: Node, { version, target }: Target): boolean {
   }
   // A browser supports an API if its version is greater than or equal
   // to the first version of the browser that API was added in
-  return semver.gte(
-    semver.coerce(customCoerce(version)),
-    semver.coerce(customCoerce(versionAdded))
-  );
+  const semverCurrent = semver.coerce(customCoerce(version));
+  const semverAdded = semver.coerce(customCoerce(versionAdded));
+
+  // semver.coerce() might be null for non-semvers (other than Safari TP)
+  // Just treat features as supported here for now to avoid lint from crashing
+  if (!semverCurrent || !semverAdded) return true;
+
+  return semver.gte(semverCurrent, semverAdded);
 }
 
 /**

--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -96,14 +96,14 @@ export function mdnSupported(node: Node, { version, target }: Target): boolean {
   if (!semverCurrent) {
     // eslint-disable-next-line no-console
     console.warn(
-      `eslint-plugin-compat: A non-semver target "${target} ${version}" matched for the feature ${node.protoChainId}, skipping`
+      `eslint-plugin-compat: A non-semver target "${target} ${version}" matched for the feature ${node.protoChainId}, skipping. You're welcome to submit this log to https://github.com/amilajack/eslint-plugin-compat/issues for analysis.`
     );
     return true;
   }
   if (!versionAdded) {
     // eslint-disable-next-line no-console
     console.warn(
-      `eslint-plugin-compat: The feature ${node.protoChainId} is supported since a non-semver target "${target} ${versionAdded}", skipping`
+      `eslint-plugin-compat: The feature ${node.protoChainId} is supported since a non-semver target "${target} ${versionAdded}", skipping. You're welcome to submit this log to https://github.com/amilajack/eslint-plugin-compat/issues for analysis.`
     );
     return true;
   }

--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -91,9 +91,22 @@ export function mdnSupported(node: Node, { version, target }: Target): boolean {
   const semverAdded = semver.coerce(customCoerce(versionAdded));
 
   // semver.coerce() might be null for non-semvers (other than Safari TP)
-  // Just treat features as supported here for now to avoid lint from crashing
-  if (!semverCurrent || !semverAdded) return true;
-
+  // Just warn and treat features as supported here for now to avoid lint from
+  // crashing
+  if (!semverCurrent) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `eslint-plugin-compat: A non-semver target "${target} ${version}" matched for the feature ${node.protoChainId}, skipping`
+    );
+    return true;
+  }
+  if (!versionAdded) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `eslint-plugin-compat: The feature ${node.protoChainId} is supported since a non-semver target "${target} ${versionAdded}", skipping`
+    );
+    return true;
+  }
   return semver.gte(semverCurrent, semverAdded);
 }
 

--- a/src/providers/MdnProvider.js
+++ b/src/providers/MdnProvider.js
@@ -79,6 +79,12 @@ export function mdnSupported(node: Node, { version, target }: Target): boolean {
   // If a version is true then it is supported but version is unsure
   if (typeof versionAdded === 'boolean') return versionAdded;
   if (versionAdded === null) return true;
+
+  // Special case for Safari TP: TP is always gte than any other releases
+  if (target === 'safari') {
+    if (version === 'TP') return true;
+    if (versionAdded === 'TP') return false;
+  }
   // A browser supports an API if its version is greater than or equal
   // to the first version of the browser that API was added in
   return semver.gte(

--- a/test/MdnProvider.spec.js
+++ b/test/MdnProvider.spec.js
@@ -1,0 +1,12 @@
+import DetermineTargetsFromConfig, { Versioning } from '../src/Versioning';
+import { getUnsupportedTargets } from '../src/providers/MdnProvider';
+
+describe('MdnProvider', () => {
+  it('should support Safari TP', () => {
+    const node = { protoChainId: 'AbortController' };
+    const config = DetermineTargetsFromConfig('.', ['safari tp']);
+    const targets = Versioning(config);
+    const result = getUnsupportedTargets(node, targets);
+    expect(result).toBeTruthy();
+  });
+});

--- a/test/MdnProvider.spec.js
+++ b/test/MdnProvider.spec.js
@@ -7,6 +7,6 @@ describe('MdnProvider', () => {
     const config = DetermineTargetsFromConfig('.', ['safari tp']);
     const targets = Versioning(config);
     const result = getUnsupportedTargets(node, targets);
-    expect(result).toBeTruthy();
+    expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
closes #284 