### PR TITLE
Remove `fixable` and add `meta.type`

### DIFF
--- a/src/rules/compat.js
+++ b/src/rules/compat.js
@@ -88,7 +88,7 @@ export default {
         'https://github.com/amilajack/eslint-plugin-compat/blob/master/docs/rules/compat.md',
       recommended: true
     },
-    fixable: 'code',
+    type: 'problem',
     schema: [{ type: 'string' }]
   },
   create(context: Context): ESLint {


### PR DESCRIPTION
Regarding removal of "fixable", per https://eslint.org/docs/developer-guide/working-with-rules#options-schemas :

> Omit the fixable property if the rule is not fixable.

Regarding `meta.type`, though generally more useful with the likes of [`eslint --fix-type`](https://eslint.org/docs/user-guide/command-line-interface#fix-type), besides for general documentation, I'm intending to release an eslint badge formatter which can count total number of violations by type (e.g., 5 problem, 10 suggestion, 4 layout violations).