### PR TITLE
feat: allow feature detection of APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v3.8.0
+
+### Added
+- Support for feature detection of APIs ([#327](https://github.com/amilajack/eslint-plugin-compat/pull/327))
+
 ### v3.7.0
 
 ### Updates

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,3 +92,9 @@ steps:
       path: $(YARN_CACHE_FOLDER)
     displayName: Cache Yarn packages
   - script: yarn --frozen-lockfile && yarn add --dev $(eslintVersion) && yarn test
+  # Upload Jest code coverage
+  - script: yarn spec --coverage --coverageReporters=cobertura
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml

--- a/src/Lint.js
+++ b/src/Lint.js
@@ -1,7 +1,25 @@
 // @flow
 import type { Node, ESLintNode } from "./LintTypes";
 
+function isInsideIfStatement(context) {
+  return context.getAncestors().some(ancestor => {
+    return ancestor.type === "IfStatement";
+  });
+}
+
+function checkNotInsideIfStatementAndReport(
+  context,
+  reporter,
+  failingRule,
+  node
+) {
+  if (!isInsideIfStatement(context)) {
+    reporter(failingRule, node);
+  }
+}
+
 export function lintCallExpression(
+  context,
   reporter: Function,
   rules: Array<Node>,
   node: ESLintNode
@@ -9,10 +27,12 @@ export function lintCallExpression(
   if (!node.callee) return;
   const calleeName = node.callee.name;
   const failingRule = rules.find(rule => rule.object === calleeName);
-  if (failingRule) reporter(failingRule, node);
+  if (failingRule)
+    checkNotInsideIfStatementAndReport(context, reporter, failingRule, node);
 }
 
 export function lintNewExpression(
+  context,
   reporter: Function,
   rules: Array<Node>,
   node: ESLintNode
@@ -20,21 +40,68 @@ export function lintNewExpression(
   if (!node.callee) return;
   const calleeName = node.callee.name;
   const failingRule = rules.find(rule => rule.object === calleeName);
-  if (failingRule) reporter(failingRule, node);
+  if (failingRule)
+    checkNotInsideIfStatementAndReport(context, reporter, failingRule, node);
+}
+
+export function lintExpressionStatement(
+  context,
+  reporter: Function,
+  rules: Node[],
+  node: ESLintNode
+) {
+  if (!node?.expression?.name) return;
+  const failingRule = rules.find(rule => rule.object === node.expression.name);
+  if (failingRule)
+    checkNotInsideIfStatementAndReport(context, reporter, failingRule, node);
+}
+
+function protoChainFromMemberExpression(node: ESLintNode): string {
+  if (node.type === "Identifier") return [node.name];
+  const protoChain = (() => {
+    switch (node.object.type) {
+      case "NewExpression":
+      case "CallExpression":
+        return protoChainFromMemberExpression(node.object.callee);
+      default:
+        return protoChainFromMemberExpression(node.object);
+    }
+  })();
+  return [...protoChain, node.property.name];
 }
 
 export function lintMemberExpression(
+  context,
   reporter: Function,
   rules: Array<Node>,
   node: ESLintNode
 ) {
   if (!node.object || !node.property) return;
-  const objectName = node.object.name;
-  const propertyName = node.property.name;
-  const failingRule = rules.find(
-    rule =>
-      rule.object === objectName &&
-      (rule.property == null || rule.property === propertyName)
-  );
-  if (failingRule) reporter(failingRule, node);
+  if (
+    !node.object.name ||
+    node.object.name === "window" ||
+    node.object.name === "globalThis"
+  ) {
+    const rawProtoChain = protoChainFromMemberExpression(node);
+    const [firstObj] = rawProtoChain;
+    const protoChain =
+      firstObj === "window" || firstObj === "globalThis"
+        ? rawProtoChain.slice(1)
+        : rawProtoChain;
+    const protoChainId = protoChain.join(".");
+    const failingRule = rules.find(rule => rule.protoChainId === protoChainId);
+    if (failingRule) {
+      checkNotInsideIfStatementAndReport(context, reporter, failingRule, node);
+    }
+  } else {
+    const objectName = node.object.name;
+    const propertyName = node.property.name;
+    const failingRule = rules.find(
+      rule =>
+        rule.object === objectName &&
+        (rule.property == null || rule.property === propertyName)
+    );
+    if (failingRule)
+      checkNotInsideIfStatementAndReport(context, reporter, failingRule, node);
+  }
 }

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -7,6 +7,47 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("compat", rule, {
   valid: [
+    // Conditional Cases
+    {
+      code: `
+        if (fetch) {
+          fetch()
+        }
+      `,
+      settings: { browsers: ["ExplorerMobile 10"] }
+    },
+    {
+      code: `
+        if (Array.prototype.flat) {
+          new Array.flat()
+        }
+      `,
+      settings: { browsers: ["ExplorerMobile 10"] }
+    },
+    {
+      code: `
+        if (fetch && otherConditions) {
+          fetch()
+        }
+      `,
+      settings: { browsers: ["ExplorerMobile 10"] }
+    },
+    {
+      code: `
+        if (window.fetch) {
+          fetch()
+        }
+      `,
+      settings: { browsers: ["ExplorerMobile 10"] }
+    },
+    {
+      code: `
+        if ('fetch' in window) {
+          fetch()
+        }
+      `,
+      settings: { browsers: ["ExplorerMobile 10"] }
+    },
     {
       code: "window",
       settings: { browsers: ["ExplorerMobile 10"] }
@@ -15,6 +56,7 @@ ruleTester.run("compat", rule, {
       code: "document.fonts()",
       settings: { browsers: ["edge 79"] }
     },
+    // Import cases
     {
       code: `
         import { Set } from 'immutable';
@@ -195,13 +237,20 @@ ruleTester.run("compat", rule, {
       settings: {
         browsers: ["chrome 49", "safari 10.1", "firefox 44"]
       }
-    },
-    {
-      code: "performance.now()",
-      settings: { browsers: ["ie 10"] }
     }
   ],
   invalid: [
+    {
+      code: "Array.from()",
+      settings: {
+        browsers: ["ie 8"]
+      },
+      errors: [
+        {
+          message: "Array.from() is not supported in IE 8"
+        }
+      ]
+    },
     {
       code: "Promise.allSettled()",
       settings: {
@@ -358,22 +407,70 @@ ruleTester.run("compat", rule, {
       ]
     },
     {
-      code: 'fetch("google.com")',
+      code: "window.document.fonts()",
+      settings: { browsers: ["ie 8"] },
+      errors: [
+        {
+          message: "document.fonts() is not supported in IE 8",
+          type: "MemberExpression"
+        }
+      ]
+    },
+    {
+      code: "new Map().size",
+      settings: { browsers: ["ie 8"] },
+      errors: [
+        {
+          message: "Map.size() is not supported in IE 8",
+          type: "MemberExpression"
+        },
+        {
+          message: "Map is not supported in IE 8",
+          type: "NewExpression"
+        }
+      ]
+    },
+    {
+      code: "new window.Map().size",
+      settings: { browsers: ["ie 8"] },
+      errors: [
+        {
+          message: "Map.size() is not supported in IE 8",
+          type: "MemberExpression"
+        },
+        {
+          message: "Map is not supported in IE 8",
+          type: "MemberExpression"
+        }
+      ]
+    },
+    {
+      code: "new Array().flat",
+      settings: { browsers: ["ie 8"] },
+      errors: [
+        {
+          message: "Array.flat() is not supported in IE 8",
+          type: "MemberExpression"
+        }
+      ]
+    },
+    {
+      code: "globalThis.fetch()",
+      settings: { browsers: ["ie 11"] },
+      errors: [
+        {
+          message: "fetch is not supported in IE 11",
+          type: "MemberExpression"
+        }
+      ]
+    },
+    {
+      code: "fetch()",
       settings: { browsers: ["ie 11"] },
       errors: [
         {
           message: "fetch is not supported in IE 11",
           type: "CallExpression"
-        }
-      ]
-    },
-    {
-      code: "new Promise()",
-      settings: { browsers: ["ie 10"] },
-      errors: [
-        {
-          message: "Promise is not supported in IE 10",
-          type: "NewExpression"
         }
       ]
     },


### PR DESCRIPTION
Previously, feature detection of APIs would report compatibility errors.  This PR fixes that. The following cases now do not error:

```js
if (fetch) {
    fetch()
}

if (Array.prototype.flat) {
    new Array.flat()
}

if (fetch && otherConditions) {
    fetch()
}

if (window.fetch) {
    fetch()
}

if ('fetch' in window) {
    fetch()
}
```

Fixes https://github.com/amilajack/eslint-plugin-compat/issues/26
Fixes https://github.com/amilajack/eslint-plugin-compat/issues/203
Fixes #185 