### PR TITLE
Check for missing object in ESLintNode

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -58,7 +58,7 @@ export function lintExpressionStatement(
 }
 
 function protoChainFromMemberExpression(node: ESLintNode): string {
-  if (node.type === "Identifier") return [node.name];
+  if (!node.object) return [node.name];
   const protoChain = (() => {
     switch (node.object.type) {
       case "NewExpression":


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'type' of undefined`.

As reported in https://github.com/amilajack/eslint-plugin-compat/issues/332#issuecomment-636502543 by @rj-david.

### How to recreate

1. Checkout https://github.com/handlebars-lang/handlebars.js
2. Update `eslint-plugin-compat` to latest version (`3.8.0-0`)
3. Run `npm run lint`