### PR TITLE
ci: automated semantic-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on: 
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Do a dry run to preview instead of a real release'     
+        required: true
+        default: 'true'
+
+env:
+  stable-node-version: "14.x"
+  e2e-eslint-version: "eslint@7" # Used because e2e and benchmark tests use ESLint's Node.js API class introduced in eslint@7 
+
+jobs:
+  authorize: 
+    name: Authorize
+    runs-on: ubuntu-18.04
+    steps:
+      - name: ${{ github.actor }} permission check to do a release
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: GET /repos/:repository/collaborators/${{ github.actor }}
+          repository: ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-18.04
+    needs: [authorize]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ stable-node-version }}
+
+      - name: node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile && yarn add --dev ${{ e2e-eslint-version }}
+
+      - name: Run tests
+        run: yarn test && yarn spec:e2e
+
+      - name: Release --dry-run  # Uses release.config.js
+        if: ${{ github.event.inputs.dryRun == 'true'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release --dry-run
+
+      - name: Release # Uses release.config.js
+        if: ${{ github.event.inputs.dryRun == 'false'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "benchmarks": "ts-node-transpile-only test/benchmarks.ts",
     "build": "rm -rf lib && babel src --out-dir lib --source-maps inline --extensions '.ts'",
-    "lint": "eslint --ignore-path .gitignore --ignore-pattern release.config.js --ext .js,.ts .",
+    "lint": "eslint --ignore-path .gitignore --ext .js,.ts .",
     "spec": "jest --testPathIgnorePatterns test/e2e-repo.spec.ts /benchmarks-tmp",
     "spec:e2e": "jest test/e2e-repo.spec.ts",
     "test": "yarn lint && yarn build && yarn spec",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "benchmarks": "ts-node-transpile-only test/benchmarks.ts",
     "build": "rm -rf lib && babel src --out-dir lib --source-maps inline --extensions '.ts'",
-    "lint": "eslint --ignore-path .gitignore --ext .js,.ts .",
+    "lint": "eslint --ignore-path .gitignore --ignore-pattern release.config.js --ext .js,.ts .",
     "spec": "jest --testPathIgnorePatterns test/e2e-repo.spec.ts /benchmarks-tmp",
     "spec:e2e": "jest test/e2e-repo.spec.ts",
     "test": "yarn lint && yarn build && yarn spec",

--- a/release.config.js
+++ b/release.config.js
@@ -1,23 +1,36 @@
 module.exports = {
-  "branches": ["master"],
-  "plugins": [
-    ["@semantic-release/commit-analyzer", {
-      "preset": "angular",
-      "parserOpts": {
-        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
-      }
-    }],
-    ["@semantic-release/release-notes-generator", {
-      "preset": "angular",
-    }],
-    ["@semantic-release/changelog", {
-      "changelogFile": "CHANGELOG.md"
-    }],
+  branches: ["master"],
+  plugins: [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "angular",
+        parserOpts: {
+          noteKeywords: ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"],
+        },
+      },
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        preset: "angular",
+      },
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        changelogFile: "CHANGELOG.md",
+      },
+    ],
     "@semantic-release/npm",
     "@semantic-release/github",
-    ["@semantic-release/git", {
-      "assets": ["package.json", "CHANGELOG.md"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }],
+    [
+      "@semantic-release/git",
+      {
+        assets: ["package.json", "CHANGELOG.md"],
+        message:
+          "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}", // eslint-disable-line no-template-curly-in-string
+      },
+    ],
   ],
-}
+};

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  "branches": ["master"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+      }
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "angular",
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    "@semantic-release/npm",
+    "@semantic-release/github",
+    ["@semantic-release/git", {
+      "assets": ["package.json", "CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+  ],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts",
-    ".eslintrc.js"
+    ".eslintrc.js",
+    "release.config.js"
   ]
 }


### PR DESCRIPTION
Builds upon #418 so that eslint-plugin-compat can have an automated release workflow. From now on updates to the following are automated:

- semver bumps
- npm registry
- CHANEGLOG.md
- GitHub release

Users with collaborator access should be able to create releases from the [actions](https://github.com/amilajack/eslint-plugin-compat/actions) page