### PR TITLE
chore(deps): updates in order to fix IE undetected compat infringements

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,14 +77,14 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "@mdn/browser-compat-data": "^2.0.7",
+    "@mdn/browser-compat-data": "^3.0.1",
     "ast-metadata-inferer": "^0.4.0",
-    "browserslist": "^4.12.2",
-    "caniuse-lite": "^1.0.30001166",
-    "core-js": "^3.6.5",
+    "browserslist": "^4.16.0",
+    "caniuse-lite": "^1.0.30001170",
+    "core-js": "^3.8.1",
     "find-up": "^4.1.0",
     "lodash.memoize": "4.1.2",
-    "semver": "7.3.2"
+    "semver": "7.3.4"
   },
   "peerDependencies": {
     "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"

--- a/test/__snapshots__/helpers.spec.ts.snap
+++ b/test/__snapshots__/helpers.spec.ts.snap
@@ -23,19 +23,19 @@ Array [
 exports[`Versioning should support multi env config in browserslist package.json 1`] = `
 Array [
   Object {
-    "parsedVersion": 8.2,
+    "parsedVersion": 10.1,
     "target": "samsung",
-    "version": "8.2",
+    "version": "10.1",
   },
   Object {
-    "parsedVersion": 12,
+    "parsedVersion": 12.1,
     "target": "safari",
-    "version": "12",
+    "version": "12.1",
   },
   Object {
-    "parsedVersion": 65,
+    "parsedVersion": 69,
     "target": "opera",
-    "version": "65",
+    "version": "69",
   },
   Object {
     "parsedVersion": 11.5,
@@ -68,19 +68,19 @@ Array [
     "version": "9",
   },
   Object {
-    "parsedVersion": 68,
+    "parsedVersion": 78,
     "target": "firefox",
-    "version": "68",
+    "version": "78",
   },
   Object {
-    "parsedVersion": 18,
+    "parsedVersion": 84,
     "target": "edge",
-    "version": "18",
+    "version": "84",
   },
   Object {
-    "parsedVersion": 79,
+    "parsedVersion": 84,
     "target": "chrome",
-    "version": "79",
+    "version": "84",
   },
   Object {
     "parsedVersion": 7,
@@ -108,14 +108,14 @@ Array [
     "version": "10.4",
   },
   Object {
-    "parsedVersion": 68,
+    "parsedVersion": 83,
     "target": "and_ff",
-    "version": "68",
+    "version": "83",
   },
   Object {
-    "parsedVersion": 81,
+    "parsedVersion": 87,
     "target": "and_chr",
-    "version": "81",
+    "version": "87",
   },
 ]
 `;
@@ -133,24 +133,24 @@ Array [
 exports[`Versioning should support resolving browserslist config in subdirectory 2`] = `
 Array [
   Object {
-    "parsedVersion": 10.1,
+    "parsedVersion": 12,
     "target": "samsung",
-    "version": "10.1",
+    "version": "12.0",
   },
   Object {
-    "parsedVersion": 13,
+    "parsedVersion": 13.1,
     "target": "safari",
-    "version": "13",
+    "version": "13.1",
   },
   Object {
-    "parsedVersion": 67,
+    "parsedVersion": 71,
     "target": "opera",
-    "version": "67",
+    "version": "71",
   },
   Object {
-    "parsedVersion": 46,
+    "parsedVersion": 59,
     "target": "op_mob",
-    "version": "46",
+    "version": "59",
   },
   Object {
     "parsedVersion": 0,
@@ -173,19 +173,19 @@ Array [
     "version": "11",
   },
   Object {
-    "parsedVersion": 68,
+    "parsedVersion": 78,
     "target": "firefox",
-    "version": "68",
+    "version": "78",
   },
   Object {
-    "parsedVersion": 18,
+    "parsedVersion": 86,
     "target": "edge",
-    "version": "18",
+    "version": "86",
   },
   Object {
-    "parsedVersion": 80,
+    "parsedVersion": 85,
     "target": "chrome",
-    "version": "80",
+    "version": "85",
   },
   Object {
     "parsedVersion": 7.12,
@@ -208,14 +208,14 @@ Array [
     "version": "10.4",
   },
   Object {
-    "parsedVersion": 68,
+    "parsedVersion": 83,
     "target": "and_ff",
-    "version": "68",
+    "version": "83",
   },
   Object {
-    "parsedVersion": 81,
+    "parsedVersion": 87,
     "target": "and_chr",
-    "version": "81",
+    "version": "87",
   },
 ]
 `;
@@ -223,19 +223,19 @@ Array [
 exports[`Versioning should support single array config in browserslist package.json 1`] = `
 Array [
   Object {
-    "parsedVersion": 8.2,
+    "parsedVersion": 10.1,
     "target": "samsung",
-    "version": "8.2",
+    "version": "10.1",
   },
   Object {
-    "parsedVersion": 12,
+    "parsedVersion": 12.1,
     "target": "safari",
-    "version": "12",
+    "version": "12.1",
   },
   Object {
-    "parsedVersion": 65,
+    "parsedVersion": 69,
     "target": "opera",
-    "version": "65",
+    "version": "69",
   },
   Object {
     "parsedVersion": 11.5,
@@ -268,19 +268,19 @@ Array [
     "version": "9",
   },
   Object {
-    "parsedVersion": 68,
+    "parsedVersion": 78,
     "target": "firefox",
-    "version": "68",
+    "version": "78",
   },
   Object {
-    "parsedVersion": 18,
+    "parsedVersion": 84,
     "target": "edge",
-    "version": "18",
+    "version": "84",
   },
   Object {
-    "parsedVersion": 73,
+    "parsedVersion": 77,
     "target": "chrome",
-    "version": "73",
+    "version": "77",
   },
   Object {
     "parsedVersion": 7,
@@ -308,14 +308,14 @@ Array [
     "version": "10.4",
   },
   Object {
-    "parsedVersion": 68,
+    "parsedVersion": 83,
     "target": "and_ff",
-    "version": "68",
+    "version": "83",
   },
   Object {
-    "parsedVersion": 81,
+    "parsedVersion": 87,
     "target": "and_chr",
-    "version": "81",
+    "version": "87",
   },
 ]
 `;
@@ -348,24 +348,24 @@ Object {
 exports[`Versioning should support string config in rule option 1`] = `
 Array [
   Object {
-    "parsedVersion": 10.1,
+    "parsedVersion": 12,
     "target": "samsung",
-    "version": "10.1",
+    "version": "12.0",
   },
   Object {
-    "parsedVersion": 13,
+    "parsedVersion": 13.1,
     "target": "safari",
-    "version": "13",
+    "version": "13.1",
   },
   Object {
-    "parsedVersion": 67,
+    "parsedVersion": 71,
     "target": "opera",
-    "version": "67",
+    "version": "71",
   },
   Object {
-    "parsedVersion": 46,
+    "parsedVersion": 59,
     "target": "op_mob",
-    "version": "46",
+    "version": "59",
   },
   Object {
     "parsedVersion": 0,
@@ -388,19 +388,19 @@ Array [
     "version": "11",
   },
   Object {
-    "parsedVersion": 68,
+    "parsedVersion": 78,
     "target": "firefox",
-    "version": "68",
+    "version": "78",
   },
   Object {
-    "parsedVersion": 18,
+    "parsedVersion": 86,
     "target": "edge",
-    "version": "18",
+    "version": "86",
   },
   Object {
-    "parsedVersion": 80,
+    "parsedVersion": 85,
     "target": "chrome",
-    "version": "80",
+    "version": "85",
   },
   Object {
     "parsedVersion": 7.12,
@@ -423,14 +423,14 @@ Array [
     "version": "10.4",
   },
   Object {
-    "parsedVersion": 68,
+    "parsedVersion": 83,
     "target": "and_ff",
-    "version": "68",
+    "version": "83",
   },
   Object {
-    "parsedVersion": 81,
+    "parsedVersion": 87,
     "target": "and_chr",
-    "version": "81",
+    "version": "87",
   },
 ]
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,10 +1472,10 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
-"@mdn/browser-compat-data@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-2.0.7.tgz#72ec37b9c1e00ce0b4e0309d753be18e2da12ee3"
-  integrity sha512-GeeM827DlzFFidn1eKkMBiqXFD2oLsnZbaiGhByPl0vcapsRzUL+t9hDoov1swc9rB2jw64R+ihtzC8qOE9wXw==
+"@mdn/browser-compat-data@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-3.0.1.tgz#2a4e6aeb4ddc627075f18c02f5abf71a3254a85f"
+  integrity sha512-m8uDiEsOz6n543SbQYoWG5s0/vHEw6B+57Px05HOVX+aiBUhp/RGtyB8vTjU0lDJea79crk6ovpvsHDaa3Vq4g==
   dependencies:
     extend "3.0.2"
 
@@ -2597,7 +2597,7 @@ browserslist-config-erb@^0.0.1:
   resolved "https://registry.yarnpkg.com/browserslist-config-erb/-/browserslist-config-erb-0.0.1.tgz#0a93648bbe11fac5b9fe555bf061f31980db64db"
   integrity sha512-QQQzCXrYVVdSWxO0UuV+f2HGBt7xdGRRvgr49W1lcwoyXNpRQFVi5cTz8+B/rLHyBkWd4JbRFeTIKHAw7BpCBg==
 
-browserslist@^4.12.0, browserslist@^4.12.2:
+browserslist@^4.12.0:
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.12.2.tgz#76653d7e4c57caa8a1a28513e2f4e197dc11a711"
   integrity sha512-MfZaeYqR8StRZdstAK9hCKDd2StvePCYp5rHzQCPicUjfFliDgmuaBNPHYUTpAywBN8+Wc/d7NYVFkO0aqaBUw==
@@ -2617,6 +2617,17 @@ browserslist@^4.14.5, browserslist@^4.14.7:
     electron-to-chromium "^1.3.591"
     escalade "^3.1.1"
     node-releases "^1.1.66"
+
+browserslist@^4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.0.tgz#410277627500be3cb28a1bfe037586fbedf9488b"
+  integrity sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==
+  dependencies:
+    caniuse-lite "^1.0.30001165"
+    colorette "^1.2.1"
+    electron-to-chromium "^1.3.621"
+    escalade "^3.1.1"
+    node-releases "^1.1.67"
 
 bser@2.1.1:
   version "2.1.1"
@@ -2756,10 +2767,10 @@ caniuse-lite@^1.0.30001157:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001163.tgz#7595ae1b430fb4ad6adcd4f0a3d705efad9dc379"
   integrity sha512-QQbOGkHWnvhn3Dlf4scPlXTZVhGOK+2qCOP5gPxqzXHhtn3tZHwNdH9qNcQRWN0f3tDYrsyXFJCFiP/GLzI5Vg==
 
-caniuse-lite@^1.0.30001166:
-  version "1.0.30001166"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001166.tgz#ca73e8747acfd16a4fd6c4b784f1b995f9698cf8"
-  integrity sha512-nCL4LzYK7F4mL0TjEMeYavafOGnBa98vTudH5c8lW9izUjnB99InG6pmC1ElAI1p0GlyZajv4ltUdFXvOHIl1A==
+caniuse-lite@^1.0.30001165, caniuse-lite@^1.0.30001170:
+  version "1.0.30001170"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
+  integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3160,6 +3171,11 @@ core-js@^3.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
+core-js@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.1.tgz#f51523668ac8a294d1285c3b9db44025fda66d47"
+  integrity sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -3555,6 +3571,11 @@ electron-to-chromium@^1.3.591:
   version "1.3.611"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.611.tgz#43a25c07ae05f9555335908abc46c89898f5afb7"
   integrity sha512-YhqTzCXtEO2h0foGLGS60ortd6yY/yUQhqDEp1VWG3DIyHvckFFyaRwR41M0/M3m7Yb8Exqh+nzyb2TuxaoMTw==
+
+electron-to-chromium@^1.3.621:
+  version "1.3.631"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.631.tgz#b28ebc7bfb348bb0aede2fae8888d775ddb6f5ee"
+  integrity sha512-mPEG/52142po0XK1jQkZtbMmp38MZtQ3JDFItYxV65WXyhxDYEQ54tP4rb93m0RbMlZqQ+4zBw2N7UumSgGfbA==
 
 electron@^9.0.5:
   version "9.0.5"
@@ -6693,7 +6714,7 @@ node-releases@^1.1.58:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.58.tgz#8ee20eef30fa60e52755fcc0942def5a734fe935"
   integrity sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==
 
-node-releases@^1.1.66:
+node-releases@^1.1.66, node-releases@^1.1.67:
   version "1.1.67"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
   integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
@@ -8270,17 +8291,17 @@ semver@7.3.2, semver@^7.2.1, semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@^6.0.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.1.2:
+semver@7.3.4, semver@^7.1.2:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 serialize-error@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
As suggested in #354, this Pull Request bumps dependencies to update compatibility data.

Only "production" dependencies were updated (to the notable exception of `find-up` in order to preserve old node support).
I can take of devs ones and update PR if asked.

Tests snapshot were updated in a dedicated commit.

Fixes https://github.com/amilajack/eslint-plugin-compat/issues/354