### PR TITLE
ci: change semantic release to run on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
         run: yarn test && yarn spec:e2e
 
       - name: Release # Uses release.config.js
-        if: ${{ github.event.inputs.dryRun == 'false'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,11 @@
 name: Release
 
-on: 
-  workflow_dispatch:
-    inputs:
-      dryRun:
-        description: 'Do a dry run to preview instead of a real release'     
-        required: true
-        default: 'true'
+on:
+  push:
+    branches:
+      - master
 
 jobs:
-  authorize: 
-    name: Authorize
-    runs-on: ubuntu-18.04
-    steps:
-      - name: ${{ github.actor }} permission check to do a release
-        uses: octokit/request-action@v2.0.17
-        with:
-          route: GET /repos/:repository/collaborators/${{ github.actor }}
-          repository: ${{ github.repository }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   release:
     name: Release
     runs-on: ubuntu-18.04
@@ -49,13 +34,6 @@ jobs:
 
       - name: Run tests
         run: yarn test && yarn spec:e2e
-
-      - name: Release --dry-run  # Uses release.config.js
-        if: ${{ github.event.inputs.dryRun == 'true'}}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release --dry-run
 
       - name: Release # Uses release.config.js
         if: ${{ github.event.inputs.dryRun == 'false'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
Makes it so that release happens on every push to master (instead of a manual workflow trigger)

Closes #437
