### PR TITLE
feat: add new CommonJS babel config files

### DIFF
--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -77,9 +77,11 @@ const items = [
   // Babel configs
   "babel.config.json",
   "babel.config.js",
+  "babel.config.cjs",
   ".babelrc",
   ".babelrc.json",
   ".babelrc.js",
+  ".babelrc.cjs",
   // TS configs
   "tsconfig.json",
 ];


### PR DESCRIPTION
babel now allows `.cjs` config files to allow ESM->CommonJS compatibility.
In an ESM package this will allow having "old" CommonJS babel config files.

Fixes #498