### PR TITLE
fix: hoist memoized fn for getting rules

### DIFF
--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -111,6 +111,41 @@ function isUsingTranspiler(context: Context): boolean {
   return false;
 }
 
+type RulesFilteredByTargets = {
+  CallExpression: AstMetadataApiWithTargetsResolver[];
+  NewExpression: AstMetadataApiWithTargetsResolver[];
+  MemberExpression: AstMetadataApiWithTargetsResolver[];
+  ExpressionStatement: AstMetadataApiWithTargetsResolver[];
+};
+
+/**
+ * A small optimization that only lints APIs that are not supported by targeted browsers.
+ * For example, if the user is targeting chrome 50, which supports the fetch API, it is
+ * wasteful to lint calls to fetch.
+ */
+const getRulesForTargets = memoize(
+  (targetsJSON: string, lintAllEsApis: boolean): RulesFilteredByTargets => {
+    const result = {
+      CallExpression: [],
+      NewExpression: [],
+      MemberExpression: [],
+      ExpressionStatement: [],
+    };
+    const targets = JSON.parse(targetsJSON);
+
+    nodes
+      .filter((node) => {
+        return lintAllEsApis ? true : node.kind !== "es";
+      })
+      .forEach((node) => {
+        if (!node.getUnsupportedTargets(node, targets).length) return;
+        result[node.astNodeType as keyof RulesFilteredByTargets].push(node);
+      });
+
+    return result;
+  }
+);
+
 export default {
   meta: {
     docs: {
@@ -139,45 +174,8 @@ export default {
       determineTargetsFromConfig(context.getFilename(), browserslistConfig)
     );
 
-    type RulesFilteredByTargets = {
-      CallExpression: AstMetadataApiWithTargetsResolver[];
-      NewExpression: AstMetadataApiWithTargetsResolver[];
-      MemberExpression: AstMetadataApiWithTargetsResolver[];
-      ExpressionStatement: AstMetadataApiWithTargetsResolver[];
-    };
-
-    /**
-     * A small optimization that only lints APIs that are not supported by targeted browsers.
-     * For example, if the user is targeting chrome 50, which supports the fetch API, it is
-     * wasteful to lint calls to fetch.
-     */
-    const getRulesForTargets = memoize(
-      (targetsJSON: string): RulesFilteredByTargets => {
-        const result = {
-          CallExpression: [],
-          NewExpression: [],
-          MemberExpression: [],
-          ExpressionStatement: [],
-        };
-        const targets = JSON.parse(targetsJSON);
-
-        nodes
-          .filter((node) => {
-            return lintAllEsApis ? true : node.kind !== "es";
-          })
-          .forEach((node) => {
-            if (!node.getUnsupportedTargets(node, targets).length) return;
-            result[node.astNodeType as keyof RulesFilteredByTargets].push(node);
-          });
-
-        return result;
-      }
-    );
-
     // Stringify to support memoization; browserslistConfig is always an array of new objects.
-    const targetedRules = getRulesForTargets(
-      JSON.stringify(browserslistTargets)
-    );
+    const targetedRules = getRulesForTargets(JSON.stringify(browserslistTargets), lintAllEsApis);
 
     type Error = {
       message: string;


### PR DESCRIPTION
In a large codebase, this gets extremely expensive and contributes to 25-30% of our total lint time (pushing it above 15 minutes).

I've lifted the memoized fn, as in the majority of cases the targetsJSON string is gonna be the same for the entire codebase, so this presents a significant savings.