### PR TITLE
fix: bump`ast-metadata-inferer` and misc fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
-  "name": "eslint-plugin-compat",
+  "name": "@yurijmikhalevich/eslint-plugin-compat",
   "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "eslint-plugin-compat",
+      "name": "@yurijmikhalevich/eslint-plugin-compat",
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "@mdn/browser-compat-data": "^4.1.5",
-        "ast-metadata-inferer": "^0.7.0",
+        "ast-metadata-inferer": "npm:@yurijmikhalevich/ast-metadata-inferer@^0.7.0",
         "browserslist": "^4.16.8",
-        "caniuse-lite": "^1.0.30001304",
+        "caniuse-lite": "^1.0.30001388",
         "core-js": "^3.16.2",
         "find-up": "^5.0.0",
         "lodash.memoize": "4.1.2",
@@ -2154,9 +2153,9 @@
       "dev": true
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.5.tgz",
-      "integrity": "sha512-rb2LEhclR/Ykf/biC2HrZmVonqnfTL8RhsL9wdMCGmw1xfeLFqGGZLKWypob2/i15SqgmEHbtcgJZ9kwWPbKtQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.0.tgz",
+      "integrity": "sha512-CVEdy5/Q2cZJXzynD3zpPWHhNpoY1AApKRW0YCWN0HdrlP+VF2+6tX5U5d7XmSL91c2kqdb7yTi93mrAhHX8zw=="
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -3142,16 +3141,13 @@
       }
     },
     "node_modules/ast-metadata-inferer": {
+      "name": "@yurijmikhalevich/ast-metadata-inferer",
       "version": "0.7.0",
-      "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+      "resolved": "https://registry.npmjs.org/@yurijmikhalevich/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+      "integrity": "sha512-0SnSKniaTtg/WFGmsTV4YYuooXGlcnOnoPrB5iIV3gIk4TT8D52WXw+ncEM+XLggWb2qcYuAii2NdfSCmeXF6A==",
       "dependencies": {
-        "@mdn/browser-compat-data": "^3.3.14"
+        "@mdn/browser-compat-data": "^5.2.0"
       }
-    },
-    "node_modules/ast-metadata-inferer/node_modules/@mdn/browser-compat-data": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
-      "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA=="
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3550,13 +3546,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001304",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz",
-      "integrity": "sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001388",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001388.tgz",
+      "integrity": "sha512-znVbq4OUjqgLxMxoNX2ZeeLR0d7lcDiE5uJ4eUiWdml1J1EkxbnQq6opT9jb9SMfJxB0XA16/ziHwni4u1I3GQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -14538,9 +14540,9 @@
       "dev": true
     },
     "@mdn/browser-compat-data": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.5.tgz",
-      "integrity": "sha512-rb2LEhclR/Ykf/biC2HrZmVonqnfTL8RhsL9wdMCGmw1xfeLFqGGZLKWypob2/i15SqgmEHbtcgJZ9kwWPbKtQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.0.tgz",
+      "integrity": "sha512-CVEdy5/Q2cZJXzynD3zpPWHhNpoY1AApKRW0YCWN0HdrlP+VF2+6tX5U5d7XmSL91c2kqdb7yTi93mrAhHX8zw=="
     },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -15311,17 +15313,11 @@
       "dev": true
     },
     "ast-metadata-inferer": {
-      "version": "0.7.0",
-      "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+      "version": "npm:@yurijmikhalevich/ast-metadata-inferer@0.7.0",
+      "resolved": "https://registry.npmjs.org/@yurijmikhalevich/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+      "integrity": "sha512-0SnSKniaTtg/WFGmsTV4YYuooXGlcnOnoPrB5iIV3gIk4TT8D52WXw+ncEM+XLggWb2qcYuAii2NdfSCmeXF6A==",
       "requires": {
-        "@mdn/browser-compat-data": "^3.3.14"
-      },
-      "dependencies": {
-        "@mdn/browser-compat-data": {
-          "version": "3.3.14",
-          "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
-          "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA=="
-        }
+        "@mdn/browser-compat-data": "^5.2.0"
       }
     },
     "astral-regex": {
@@ -15624,9 +15620,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001304",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz",
-      "integrity": "sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ=="
+      "version": "1.0.30001388",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001388.tgz",
+      "integrity": "sha512-znVbq4OUjqgLxMxoNX2ZeeLR0d7lcDiE5uJ4eUiWdml1J1EkxbnQq6opT9jb9SMfJxB0XA16/ziHwni4u1I3GQ=="
     },
     "cardinal": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -84,10 +84,9 @@
     "semi": true
   },
   "dependencies": {
-    "@mdn/browser-compat-data": "^4.1.5",
-    "ast-metadata-inferer": "^0.7.0",
+    "ast-metadata-inferer": "npm:@yurijmikhalevich/ast-metadata-inferer@^0.7.0",
     "browserslist": "^4.16.8",
-    "caniuse-lite": "^1.0.30001304",
+    "caniuse-lite": "^1.0.30001388",
     "core-js": "^3.16.2",
     "find-up": "^5.0.0",
     "lodash.memoize": "4.1.2",

--- a/src/providers/mdn-provider.ts
+++ b/src/providers/mdn-provider.ts
@@ -96,6 +96,11 @@ export function isSupportedByMDN(
     if (version === "TP") return true;
     if (versionAdded === "TP") return false;
   }
+
+  // "preview" is always gte than any other releases
+  if (version === "preview") return true;
+  if (versionAdded === "preview") return false;
+
   // A browser supports an API if its version is greater than or equal
   // to the first version of the browser that API was added in
   const semverCurrent = semver.coerce(customCoerce(version.toString()));

--- a/src/providers/mdn-provider.ts
+++ b/src/providers/mdn-provider.ts
@@ -98,7 +98,7 @@ export function isSupportedByMDN(
   }
   // A browser supports an API if its version is greater than or equal
   // to the first version of the browser that API was added in
-  const semverCurrent = semver.coerce(customCoerce(version));
+  const semverCurrent = semver.coerce(customCoerce(version.toString()));
   const semverAdded = semver.coerce(customCoerce(versionAdded));
 
   // semver.coerce() might be null for non-semvers (other than Safari TP)
@@ -111,7 +111,7 @@ export function isSupportedByMDN(
     );
     return true;
   }
-  if (!versionAdded) {
+  if (!semverAdded) {
     // eslint-disable-next-line no-console
     console.warn(
       `eslint-plugin-compat: The feature ${node.protoChainId} is supported since a non-semver target "${target} ${versionAdded}", skipping. You're welcome to submit this log to https://github.com/amilajack/eslint-plugin-compat/issues for analysis.`

--- a/test/__snapshots__/helpers.spec.ts.snap
+++ b/test/__snapshots__/helpers.spec.ts.snap
@@ -23,19 +23,19 @@ Array [
 exports[`Versioning should support multi env config in browserslist package.json 1`] = `
 Array [
   Object {
-    "parsedVersion": 13,
+    "parsedVersion": 15,
     "target": "samsung",
-    "version": "13.0",
+    "version": "15.0",
   },
   Object {
-    "parsedVersion": 14.1,
+    "parsedVersion": 15.2,
     "target": "safari",
-    "version": "14.1",
+    "version": "15.2-15.3",
   },
   Object {
-    "parsedVersion": 79,
+    "parsedVersion": 87,
     "target": "opera",
-    "version": "79",
+    "version": "87",
   },
   Object {
     "parsedVersion": 11.5,
@@ -53,9 +53,9 @@ Array [
     "version": "2.5",
   },
   Object {
-    "parsedVersion": 14,
+    "parsedVersion": 14.5,
     "target": "ios_saf",
-    "version": "14.0-14.4",
+    "version": "14.5-14.8",
   },
   Object {
     "parsedVersion": 10,
@@ -73,14 +73,14 @@ Array [
     "version": "78",
   },
   Object {
-    "parsedVersion": 94,
+    "parsedVersion": 102,
     "target": "edge",
-    "version": "94",
+    "version": "102",
   },
   Object {
-    "parsedVersion": 94,
+    "parsedVersion": 102,
     "target": "chrome",
-    "version": "94",
+    "version": "102",
   },
   Object {
     "parsedVersion": 7,
@@ -93,9 +93,9 @@ Array [
     "version": "7.12",
   },
   Object {
-    "parsedVersion": 97,
+    "parsedVersion": 104,
     "target": "android",
-    "version": "97",
+    "version": "104",
   },
   Object {
     "parsedVersion": 12.12,
@@ -108,14 +108,14 @@ Array [
     "version": "10.4",
   },
   Object {
-    "parsedVersion": 95,
+    "parsedVersion": 101,
     "target": "and_ff",
-    "version": "95",
+    "version": "101",
   },
   Object {
-    "parsedVersion": 97,
+    "parsedVersion": 104,
     "target": "and_chr",
-    "version": "97",
+    "version": "104",
   },
 ]
 `;
@@ -133,19 +133,19 @@ Array [
 exports[`Versioning should support resolving browserslist config in subdirectory 2`] = `
 Array [
   Object {
-    "parsedVersion": 15,
+    "parsedVersion": 17,
     "target": "samsung",
-    "version": "15.0",
+    "version": "17.0",
   },
   Object {
-    "parsedVersion": 13.1,
+    "parsedVersion": 15.5,
     "target": "safari",
-    "version": "13.1",
+    "version": "15.5",
   },
   Object {
-    "parsedVersion": 81,
+    "parsedVersion": 89,
     "target": "opera",
-    "version": "81",
+    "version": "89",
   },
   Object {
     "parsedVersion": 64,
@@ -163,9 +163,9 @@ Array [
     "version": "2.5",
   },
   Object {
-    "parsedVersion": 12.2,
+    "parsedVersion": 14.5,
     "target": "ios_saf",
-    "version": "12.2-12.5",
+    "version": "14.5-14.8",
   },
   Object {
     "parsedVersion": 11,
@@ -178,14 +178,14 @@ Array [
     "version": "78",
   },
   Object {
-    "parsedVersion": 96,
+    "parsedVersion": 103,
     "target": "edge",
-    "version": "96",
+    "version": "103",
   },
   Object {
-    "parsedVersion": 94,
+    "parsedVersion": 103,
     "target": "chrome",
-    "version": "94",
+    "version": "103",
   },
   Object {
     "parsedVersion": 7.12,
@@ -193,9 +193,9 @@ Array [
     "version": "7.12",
   },
   Object {
-    "parsedVersion": 97,
+    "parsedVersion": 104,
     "target": "android",
-    "version": "97",
+    "version": "104",
   },
   Object {
     "parsedVersion": 12.12,
@@ -208,14 +208,14 @@ Array [
     "version": "10.4",
   },
   Object {
-    "parsedVersion": 95,
+    "parsedVersion": 101,
     "target": "and_ff",
-    "version": "95",
+    "version": "101",
   },
   Object {
-    "parsedVersion": 97,
+    "parsedVersion": 104,
     "target": "and_chr",
-    "version": "97",
+    "version": "104",
   },
 ]
 `;
@@ -223,19 +223,19 @@ Array [
 exports[`Versioning should support single array config in browserslist package.json 1`] = `
 Array [
   Object {
-    "parsedVersion": 13,
+    "parsedVersion": 15,
     "target": "samsung",
-    "version": "13.0",
+    "version": "15.0",
   },
   Object {
-    "parsedVersion": 14.1,
+    "parsedVersion": 15.2,
     "target": "safari",
-    "version": "14.1",
+    "version": "15.2-15.3",
   },
   Object {
-    "parsedVersion": 79,
+    "parsedVersion": 87,
     "target": "opera",
-    "version": "79",
+    "version": "87",
   },
   Object {
     "parsedVersion": 11.5,
@@ -253,9 +253,9 @@ Array [
     "version": "2.5",
   },
   Object {
-    "parsedVersion": 14,
+    "parsedVersion": 14.5,
     "target": "ios_saf",
-    "version": "14.0-14.4",
+    "version": "14.5-14.8",
   },
   Object {
     "parsedVersion": 10,
@@ -273,14 +273,14 @@ Array [
     "version": "78",
   },
   Object {
-    "parsedVersion": 94,
+    "parsedVersion": 102,
     "target": "edge",
-    "version": "94",
+    "version": "102",
   },
   Object {
-    "parsedVersion": 88,
+    "parsedVersion": 96,
     "target": "chrome",
-    "version": "88",
+    "version": "96",
   },
   Object {
     "parsedVersion": 7,
@@ -293,9 +293,9 @@ Array [
     "version": "7.12",
   },
   Object {
-    "parsedVersion": 97,
+    "parsedVersion": 104,
     "target": "android",
-    "version": "97",
+    "version": "104",
   },
   Object {
     "parsedVersion": 12.12,
@@ -308,14 +308,14 @@ Array [
     "version": "10.4",
   },
   Object {
-    "parsedVersion": 95,
+    "parsedVersion": 101,
     "target": "and_ff",
-    "version": "95",
+    "version": "101",
   },
   Object {
-    "parsedVersion": 97,
+    "parsedVersion": 104,
     "target": "and_chr",
-    "version": "97",
+    "version": "104",
   },
 ]
 `;
@@ -348,19 +348,19 @@ Array [
 exports[`Versioning should support string config in rule option 1`] = `
 Array [
   Object {
-    "parsedVersion": 15,
+    "parsedVersion": 17,
     "target": "samsung",
-    "version": "15.0",
+    "version": "17.0",
   },
   Object {
-    "parsedVersion": 13.1,
+    "parsedVersion": 15.5,
     "target": "safari",
-    "version": "13.1",
+    "version": "15.5",
   },
   Object {
-    "parsedVersion": 81,
+    "parsedVersion": 89,
     "target": "opera",
-    "version": "81",
+    "version": "89",
   },
   Object {
     "parsedVersion": 64,
@@ -378,9 +378,9 @@ Array [
     "version": "2.5",
   },
   Object {
-    "parsedVersion": 12.2,
+    "parsedVersion": 14.5,
     "target": "ios_saf",
-    "version": "12.2-12.5",
+    "version": "14.5-14.8",
   },
   Object {
     "parsedVersion": 11,
@@ -393,14 +393,14 @@ Array [
     "version": "78",
   },
   Object {
-    "parsedVersion": 96,
+    "parsedVersion": 103,
     "target": "edge",
-    "version": "96",
+    "version": "103",
   },
   Object {
-    "parsedVersion": 94,
+    "parsedVersion": 103,
     "target": "chrome",
-    "version": "94",
+    "version": "103",
   },
   Object {
     "parsedVersion": 7.12,
@@ -408,9 +408,9 @@ Array [
     "version": "7.12",
   },
   Object {
-    "parsedVersion": 97,
+    "parsedVersion": 104,
     "target": "android",
-    "version": "97",
+    "version": "104",
   },
   Object {
     "parsedVersion": 12.12,
@@ -423,14 +423,14 @@ Array [
     "version": "10.4",
   },
   Object {
-    "parsedVersion": 95,
+    "parsedVersion": 101,
     "target": "and_ff",
-    "version": "95",
+    "version": "101",
   },
   Object {
-    "parsedVersion": 97,
+    "parsedVersion": 104,
     "target": "and_chr",
-    "version": "97",
+    "version": "104",
   },
 ]
 `;

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -75,7 +75,7 @@ describe("Versioning", () => {
 
   it("should fail on incorrect browserslist target version", () => {
     expect(() => {
-      determineTargetsFromConfig(".", "edge 100");
-    }).toThrow("Unknown version 100 of edge");
+      determineTargetsFromConfig(".", "edge 200");
+    }).toThrow("Unknown version 200 of edge");
   });
 });


### PR DESCRIPTION
This PR updates `ast-metadata-inferer` (installing from `@yurijmikhalevich` scope should be replaced after [this PR](https://github.com/amilajack/ast-metadata-inferer/pull/145) is merged) and closes #524.