### PR TITLE
fix: findUp is not defined

### DIFF
--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -6,6 +6,7 @@
  *   Gets protochain for the ESLint nodes the plugin is interested in
  */
 import fs from "fs";
+import findUp from "find-up";
 import memoize from "lodash.memoize";
 import {
   lintCallExpression,


### PR DESCRIPTION
This PR fixes issue #528 by adding a missing line to `src/rules/compat.ts`