### PR TITLE
Allow installation on Node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "engines": {
-    "node": ">=16.x"
+    "node": ">=14.x"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Version 4.1.2 dropped support for Node < 16.
This information was not included in the release notes.

Is it possible to support at least Node >= 14? If not, I'll be stuck with 4.1.1 for a long time.