### PR TITLE
fix(helpers): Fix prototype construction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
-        "@mdn/browser-compat-data": "^5.2.34",
-        "ast-metadata-inferer": "^0.7.0",
+        "@mdn/browser-compat-data": "^5.2.47",
+        "ast-metadata-inferer": "^0.8.0",
         "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001451",
+        "caniuse-lite": "^1.0.30001473",
         "find-up": "^5.0.0",
         "lodash.memoize": "4.1.2",
         "semver": "7.3.8"
@@ -1284,9 +1284,9 @@
       "dev": true
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.34",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.34.tgz",
-      "integrity": "sha512-Z2YDZ+wTOo9q7ztKndznivTbPk+DOVDUcc8Gdq3nE00AErSZlt/aWNlE33lVfR/7FcP9Zz3uaSA2nBzOGGrh8A=="
+      "version": "5.2.47",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.47.tgz",
+      "integrity": "sha512-6/QvoKeooo3J/WL7i9yjfDtUkqOZW8K6aqdzcw+bz4YdgMBzBQVZU7vZmEdCGOcV5AlsBHZT38mqx/sTrnZMDQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2520,17 +2520,12 @@
       }
     },
     "node_modules/ast-metadata-inferer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
-      "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.0.tgz",
+      "integrity": "sha512-jOMKcHht9LxYIEQu+RVd22vtgrPaVCtDRQ/16IGmurdzxvYbDd5ynxjnyrzLnieG96eTcAyaoj/wN/4/1FyyeA==",
       "dependencies": {
-        "@mdn/browser-compat-data": "^3.3.14"
+        "@mdn/browser-compat-data": "^5.2.34"
       }
-    },
-    "node_modules/ast-metadata-inferer/node_modules/@mdn/browser-compat-data": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
-      "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA=="
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
@@ -2888,9 +2883,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001451",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
-      "integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==",
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
+      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2899,6 +2894,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -4087,6 +4086,21 @@
       "peerDependencies": {
         "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/ast-metadata-inferer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+      "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+      "dev": true,
+      "dependencies": {
+        "@mdn/browser-compat-data": "^3.3.14"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/ast-metadata-inferer/node_modules/@mdn/browser-compat-data": {
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
+      "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
+      "dev": true
     },
     "node_modules/eslint-plugin-eslint-plugin": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -83,10 +83,10 @@
     "semi": true
   },
   "dependencies": {
-    "@mdn/browser-compat-data": "^5.2.34",
-    "ast-metadata-inferer": "^0.7.0",
+    "@mdn/browser-compat-data": "^5.2.47",
+    "ast-metadata-inferer": "^0.8.0",
     "browserslist": "^4.21.5",
-    "caniuse-lite": "^1.0.30001451",
+    "caniuse-lite": "^1.0.30001473",
     "find-up": "^5.0.0",
     "lodash.memoize": "4.1.2",
     "semver": "7.3.8"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -91,17 +91,22 @@ export function lintExpressionStatement(
     );
 }
 
+function isStringLiteral(node: ESLintNode): boolean {
+  return node.type === "Literal" && typeof node.value === "string";
+}
+
 function protoChainFromMemberExpression(node: ESLintNode): string[] {
   if (!node.object) return [node.name];
   const protoChain = (() => {
-    switch (node.object.type) {
-      case "NewExpression":
-      case "CallExpression":
-        return protoChainFromMemberExpression(node.object.callee!);
-      case "Literal":
-        return ["String"];
-      default:
-        return protoChainFromMemberExpression(node.object);
+    if (
+      node.object.type === "NewExpression" ||
+      node.object.type === "CallExpression"
+    ) {
+      return protoChainFromMemberExpression(node.object.callee!);
+    } else if (isStringLiteral(node.object)) {
+      return ["String"];
+    } else {
+      return protoChainFromMemberExpression(node.object);
     }
   })();
   return [...protoChain, node.property!.name];

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -103,6 +103,8 @@ function protoChainFromMemberExpression(node: ESLintNode): string[] {
       node.object.type === "CallExpression"
     ) {
       return protoChainFromMemberExpression(node.object.callee!);
+    } else if (node.object.type === "ArrayExpression") {
+      return ["Array"];
     } else if (isStringLiteral(node.object)) {
       return ["String"];
     } else {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -98,6 +98,8 @@ function protoChainFromMemberExpression(node: ESLintNode): string[] {
       case "NewExpression":
       case "CallExpression":
         return protoChainFromMemberExpression(node.object.callee!);
+      case "Literal":
+        return ["String"];
       default:
         return protoChainFromMemberExpression(node.object);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type TargetNames = Array<string>;
 export type ESLintNode = {
   name: string;
   type: string;
+  value?: unknown;
   object?: ESLintNode;
   parent?: ESLintNode;
   expression?: ESLintNode;

--- a/test/__snapshots__/helpers.spec.ts.snap
+++ b/test/__snapshots__/helpers.spec.ts.snap
@@ -23,19 +23,19 @@ exports[`Versioning should get lowest target versions 1`] = `
 exports[`Versioning should support multi env config in browserslist package.json 1`] = `
 [
   {
-    "parsedVersion": 16,
+    "parsedVersion": 17,
     "target": "samsung",
-    "version": "16.0",
+    "version": "17.0",
   },
   {
-    "parsedVersion": 15.6,
+    "parsedVersion": 16.1,
     "target": "safari",
-    "version": "15.6",
+    "version": "16.1",
   },
   {
-    "parsedVersion": 91,
+    "parsedVersion": 92,
     "target": "opera",
-    "version": "91",
+    "version": "92",
   },
   {
     "parsedVersion": 11.5,
@@ -73,14 +73,14 @@ exports[`Versioning should support multi env config in browserslist package.json
     "version": "102",
   },
   {
-    "parsedVersion": 106,
+    "parsedVersion": 108,
     "target": "edge",
-    "version": "106",
+    "version": "108",
   },
   {
-    "parsedVersion": 106,
+    "parsedVersion": 108,
     "target": "chrome",
-    "version": "106",
+    "version": "108",
   },
   {
     "parsedVersion": 7,
@@ -93,9 +93,9 @@ exports[`Versioning should support multi env config in browserslist package.json
     "version": "13.18",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 111,
     "target": "android",
-    "version": "109",
+    "version": "111",
   },
   {
     "parsedVersion": 13.4,
@@ -108,14 +108,14 @@ exports[`Versioning should support multi env config in browserslist package.json
     "version": "13.1",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 110,
     "target": "and_ff",
-    "version": "109",
+    "version": "110",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 111,
     "target": "and_chr",
-    "version": "109",
+    "version": "111",
   },
 ]
 `;
@@ -133,9 +133,9 @@ exports[`Versioning should support resolving browserslist config in subdirectory
 exports[`Versioning should support resolving browserslist config in subdirectory 2`] = `
 [
   {
-    "parsedVersion": 18,
+    "parsedVersion": 19,
     "target": "samsung",
-    "version": "18.0",
+    "version": "19.0",
   },
   {
     "parsedVersion": 15.6,
@@ -143,9 +143,9 @@ exports[`Versioning should support resolving browserslist config in subdirectory
     "version": "15.6",
   },
   {
-    "parsedVersion": 93,
+    "parsedVersion": 94,
     "target": "opera",
-    "version": "93",
+    "version": "94",
   },
   {
     "parsedVersion": 73,
@@ -173,9 +173,9 @@ exports[`Versioning should support resolving browserslist config in subdirectory
     "version": "102",
   },
   {
-    "parsedVersion": 108,
+    "parsedVersion": 109,
     "target": "edge",
-    "version": "108",
+    "version": "109",
   },
   {
     "parsedVersion": 108,
@@ -183,9 +183,9 @@ exports[`Versioning should support resolving browserslist config in subdirectory
     "version": "108",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 111,
     "target": "android",
-    "version": "109",
+    "version": "111",
   },
   {
     "parsedVersion": 13.4,
@@ -198,14 +198,14 @@ exports[`Versioning should support resolving browserslist config in subdirectory
     "version": "13.1",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 110,
     "target": "and_ff",
-    "version": "109",
+    "version": "110",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 111,
     "target": "and_chr",
-    "version": "109",
+    "version": "111",
   },
 ]
 `;
@@ -213,19 +213,19 @@ exports[`Versioning should support resolving browserslist config in subdirectory
 exports[`Versioning should support single array config in browserslist package.json 1`] = `
 [
   {
-    "parsedVersion": 16,
+    "parsedVersion": 17,
     "target": "samsung",
-    "version": "16.0",
+    "version": "17.0",
   },
   {
-    "parsedVersion": 15.6,
+    "parsedVersion": 16.1,
     "target": "safari",
-    "version": "15.6",
+    "version": "16.1",
   },
   {
-    "parsedVersion": 91,
+    "parsedVersion": 92,
     "target": "opera",
-    "version": "91",
+    "version": "92",
   },
   {
     "parsedVersion": 11.5,
@@ -263,14 +263,14 @@ exports[`Versioning should support single array config in browserslist package.j
     "version": "102",
   },
   {
-    "parsedVersion": 106,
+    "parsedVersion": 108,
     "target": "edge",
-    "version": "106",
+    "version": "108",
   },
   {
-    "parsedVersion": 100,
+    "parsedVersion": 102,
     "target": "chrome",
-    "version": "100",
+    "version": "102",
   },
   {
     "parsedVersion": 7,
@@ -283,9 +283,9 @@ exports[`Versioning should support single array config in browserslist package.j
     "version": "13.18",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 111,
     "target": "android",
-    "version": "109",
+    "version": "111",
   },
   {
     "parsedVersion": 13.4,
@@ -298,14 +298,14 @@ exports[`Versioning should support single array config in browserslist package.j
     "version": "13.1",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 110,
     "target": "and_ff",
-    "version": "109",
+    "version": "110",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 111,
     "target": "and_chr",
-    "version": "109",
+    "version": "111",
   },
 ]
 `;
@@ -313,9 +313,9 @@ exports[`Versioning should support single array config in browserslist package.j
 exports[`Versioning should support string config in rule option 1`] = `
 [
   {
-    "parsedVersion": 18,
+    "parsedVersion": 19,
     "target": "samsung",
-    "version": "18.0",
+    "version": "19.0",
   },
   {
     "parsedVersion": 15.6,
@@ -323,9 +323,9 @@ exports[`Versioning should support string config in rule option 1`] = `
     "version": "15.6",
   },
   {
-    "parsedVersion": 93,
+    "parsedVersion": 94,
     "target": "opera",
-    "version": "93",
+    "version": "94",
   },
   {
     "parsedVersion": 73,
@@ -353,9 +353,9 @@ exports[`Versioning should support string config in rule option 1`] = `
     "version": "102",
   },
   {
-    "parsedVersion": 108,
+    "parsedVersion": 109,
     "target": "edge",
-    "version": "108",
+    "version": "109",
   },
   {
     "parsedVersion": 108,
@@ -363,9 +363,9 @@ exports[`Versioning should support string config in rule option 1`] = `
     "version": "108",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 111,
     "target": "android",
-    "version": "109",
+    "version": "111",
   },
   {
     "parsedVersion": 13.4,
@@ -378,14 +378,14 @@ exports[`Versioning should support string config in rule option 1`] = `
     "version": "13.1",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 110,
     "target": "and_ff",
-    "version": "109",
+    "version": "110",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 111,
     "target": "and_chr",
-    "version": "109",
+    "version": "111",
   },
 ]
 `;

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -632,6 +632,17 @@ ruleTester.run("compat", rule, {
         },
       ],
     },
+    {
+      code: "[].at(5)",
+      settings: {
+        browsers: ["ie 11", "safari 12"],
+      },
+      errors: [
+        {
+          message: "Array.at() is not supported in Safari 12, IE 11",
+        },
+      ],
+    },
     // @TODO: Fix this edge case
     // {
     //   code: `window?.fetch`,

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -621,6 +621,17 @@ ruleTester.run("compat", rule, {
         },
       ],
     },
+    {
+      code: "'foo'.at(5)",
+      settings: {
+        browsers: ["ie 11", "safari 12"],
+      },
+      errors: [
+        {
+          message: "String.at() is not supported in Safari 12, IE 11",
+        },
+      ],
+    },
     // @TODO: Fix this edge case
     // {
     //   code: `window?.fetch`,


### PR DESCRIPTION
The protochain array was coming back as `[undefined, 'at']` for `"foo".at(1)` rather than coming back as `["String", "at"]` which makes it look up the correct compat data in the dataset.

I check for a string literal and return `["String"]` for it in member expressions so that the protochain key is created correctly.

I did the same fix for `ArrayExpression` so that the constructed protochain returns `"Array"` and I also added an e2e test and updated the compatibility databases.

Fixes: #395, https://github.com/amilajack/eslint-plugin-compat/issues/539, #445, https://github.com/amilajack/eslint-plugin-compat/issues/540