### PR TITLE
update semver (audit problem)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "caniuse-lite": "^1.0.30001473",
         "find-up": "^5.0.0",
         "lodash.memoize": "4.1.2",
-        "semver": "7.3.8"
+        "semver": "7.5.4"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.2",
@@ -27,7 +27,7 @@
         "@types/eslint": "^8.21.0",
         "@types/jest": "^29.4.0",
         "@types/lodash.memoize": "^4.1.7",
-        "@types/semver": "^7.3.13",
+        "@types/semver": "7.5.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "benchmark": "^2.1.4",
@@ -49,7 +49,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=16.x"
+        "node": ">=14.x"
       },
       "peerDependencies": {
         "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2041,9 +2041,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -4099,6 +4099,39 @@
       "version": "3.3.14",
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
       "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-compat/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "node_modules/eslint-plugin-eslint-plugin": {
@@ -11344,9 +11377,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/eslint": "^8.21.0",
     "@types/jest": "^29.4.0",
     "@types/lodash.memoize": "^4.1.7",
-    "@types/semver": "^7.3.13",
+    "@types/semver": "7.5.0",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "benchmark": "^2.1.4",
@@ -89,7 +89,7 @@
     "caniuse-lite": "^1.0.30001473",
     "find-up": "^5.0.0",
     "lodash.memoize": "4.1.2",
-    "semver": "7.3.8"
+    "semver": "7.5.4"
   },
   "peerDependencies": {
     "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"


### PR DESCRIPTION
```
# npm audit report

semver  7.0.0 - 7.5.1
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
```

```
├─┬ eslint-plugin-compat@4.1.4
│ └── semver@7.3.8
```

I don't know why you don't use `^`, so I left it the same. By the way, if not for this, the PR would not be needed.

I propose as an alternative https://github.com/amilajack/eslint-plugin-compat/pull/583 . I think it's more likely that the problem will be solved.