### PR TITLE
Add support for ignoring native browserslist resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ Add polyfills to the settings section of your eslint config. Append the name of 
 }
 ```
 
+## Ignoring Browserslist native resolution
+
+To exclude targets picked up by your browserslist config and only use targets explictly provided via ESLint:
+
+```jsonc
+{
+  // ...
+  "rules": {
+    "compat/compat": [ "error", {
+      "query": "node 18",
+      "ignoreBrowserslistTargets": true
+    } ]
+  }
+}
+```
+
 ## Linting ES APIs (Experimental)
 
 This plugin also supports linting the compatibility of ES APIs in addition to Web APIs. This is an experimental feature and is disabled by default. To enable this feature, add the following to your eslint config:

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -185,31 +185,32 @@ export function determineTargetsFromConfig(
   const browserslistOpts = { path: configPath };
 
   const eslintTargets = (() => {
-    // Get targets from eslint settings
-    if (Array.isArray(config) || typeof config === "string") {
-      return browserslist(config, browserslistOpts);
-    }
-    if (config && typeof config === "object") {
-      return browserslist(
-        [...(config.production || []), ...(config.development || [])],
-        browserslistOpts
-      );
-    }
-    return [];
+    const query = config
+      ? Array.isArray(config) || typeof config === "string"
+        ? config
+        : "query" in config
+        ? config.query
+        : [...(config.production || []), ...(config.development || [])]
+      : [];
+    return query.length ? browserslist(query, browserslistOpts) : [];
   })();
 
-  if (browserslist.findConfig(configPath)) {
-    // If targets are defined in ESLint and browerslist configs, merge the targets together
-    if (eslintTargets.length) {
-      const browserslistTargets = browserslist(undefined, browserslistOpts);
-      return Array.from(new Set(eslintTargets.concat(browserslistTargets)));
-    }
-  } else if (eslintTargets.length) {
+  // Determine if targets picked up by browserslist should be included
+  const ignoreBrowserslistTargets =
+    config && "object" === typeof config && "query" in config
+      ? Boolean(config.ignoreBrowserslistTargets)
+      : // Included for backwards-compatibility; remove in next major version (return false instead)
+        !browserslist.findConfig(configPath) && eslintTargets.length > 0;
+
+  if (ignoreBrowserslistTargets) {
     return eslintTargets;
   }
 
   // Get targets fron browserslist configs
-  return browserslist(undefined, browserslistOpts);
+  const browserslistTargets = browserslist(undefined, browserslistOpts);
+
+  // If targets are defined in ESLint and browerslist configs, merge the targets together
+  return Array.from(new Set(eslintTargets.concat(browserslistTargets)));
 }
 
 /**

--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -146,7 +146,29 @@ export default {
       recommended: true,
     },
     type: "problem",
-    schema: [{ type: "string" }],
+    schema: [
+      {
+        oneOf: [
+          { type: "string" },
+          {
+            additionalProperties: false,
+            properties: {
+              ignoreBrowserslistTargets: {
+                type: "boolean",
+              },
+              query: {
+                oneOf: [
+                  { type: "string" },
+                  { items: { type: "string" }, type: "array" },
+                ],
+              },
+            },
+            required: ["query"],
+            type: "object",
+          },
+        ],
+      },
+    ],
   },
   create(context: Context): ESLint {
     // Determine lowest targets from browserslist config, which reads user's

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,10 @@ export type BrowserListConfig =
       production?: Array<string>;
       development?: Array<string>;
     }
+  | {
+      ignoreBrowserslistTargets?: boolean;
+      query: string | Array<string>;
+    }
   | null;
 
 // @TODO Replace with types from ast-metadata-inferer

--- a/test/__snapshots__/helpers.spec.ts.snap
+++ b/test/__snapshots__/helpers.spec.ts.snap
@@ -120,6 +120,46 @@ exports[`Versioning should support multi env config in browserslist package.json
 ]
 `;
 
+exports[`Versioning should support object config in rule option 1`] = `
+[
+  {
+    "parsedVersion": 18.14,
+    "target": "node",
+    "version": "18.14.0",
+  },
+  {
+    "parsedVersion": 70,
+    "target": "chrome",
+    "version": "70",
+  },
+]
+`;
+
+exports[`Versioning should support object config with ignore option in rule option 1`] = `
+[
+  {
+    "parsedVersion": 18.14,
+    "target": "node",
+    "version": "18.14.0",
+  },
+]
+`;
+
+exports[`Versioning should support object config with query array in rule option 1`] = `
+[
+  {
+    "parsedVersion": 18.14,
+    "target": "node",
+    "version": "18.14.0",
+  },
+  {
+    "parsedVersion": 70,
+    "target": "chrome",
+    "version": "70",
+  },
+]
+`;
+
 exports[`Versioning should support resolving browserslist config in subdirectory 1`] = `
 [
   {

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -91,6 +91,40 @@ describe("Versioning", () => {
     expect(result).toMatchSnapshot();
   });
 
+  it("should support object config in rule option", () => {
+    const config = determineTargetsFromConfig(
+      path.join(__dirname, ".browserslistrc"),
+      {
+        query: "node 18",
+      }
+    );
+    const result = parseBrowsersListVersion(config);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("should support object config with query array in rule option", () => {
+    const config = determineTargetsFromConfig(
+      path.join(__dirname, ".browserslistrc"),
+      {
+        query: ["node 18"],
+      }
+    );
+    const result = parseBrowsersListVersion(config);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("should support object config with ignore option in rule option", () => {
+    const config = determineTargetsFromConfig(
+      path.join(__dirname, ".browserslistrc"),
+      {
+        query: "node 18",
+        ignoreBrowserslistTargets: true,
+      }
+    );
+    const result = parseBrowsersListVersion(config);
+    expect(result).toMatchSnapshot();
+  });
+
   it("should fail on incorrect browserslist target version", () => {
     expect(() => {
       determineTargetsFromConfig(".", "edge 100000");


### PR DESCRIPTION
Fixes #411 

Consider a scenario where a project contains code destined for NodeJS except for the `src` directory which is for browsers. The project has the following browserslist config:

```
{
  browserslist: {
    production: ["defaults"],
    node: ["node 18"],
  },
}
```

We want `compat/compat` to use the "node" env for everything except the `src` directory, and "production" (browserslist default env) within `src`. This is currently not possible since additional targets are always merged with browserslist-resolved targets (when config is present).

This change adds support for a new options structure (with full BC):

```
{
  rules: {
    "compat/compat": ["error", {
      ignoreBrowserslistTargets?: boolean; (default: false)
      query: string | string[];
    } ],
  },
}
```

Setting `ignoreBrowserslistTargets: true` will prevent merging targets provided in `query` with the ones resolved by browserslist.

We can now do something like this:


```
{
  rules: {
    "compat/compat": ["error", {
      ignoreBrowserslistTargets: true,
      query: require('browserslist').findConfig(__dirname).node,
    }],
  },
  overrides: [
    {
      files: ["src/"],
      rules: {
        "compat/compat": "error"
      },
    },
  ],
}
```

The targets defined in the "node" browserslist environment will now be used everywhere in the project except within the `src` directory where the "production" environment will be used instead.