### PR TITLE
feat: Enable setting Browserslist JS API options

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,6 +7,7 @@ import {
   Target,
   HandleFailingRule,
   Context,
+  BrowsersListOpts,
 } from "./types";
 import { TargetNameMappings } from "./constants";
 
@@ -180,9 +181,10 @@ export function reverseTargetMappings<K extends string, V extends string>(
  */
 export function determineTargetsFromConfig(
   configPath: string,
-  config?: BrowserListConfig
+  config?: BrowserListConfig,
+  browserslistOptsFromConfig?: BrowsersListOpts
 ): Array<string> {
-  const browserslistOpts = { path: configPath };
+  const browserslistOpts = { path: configPath, ...browserslistOptsFromConfig };
 
   const eslintTargets = (() => {
     // Get targets from eslint settings

--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -23,6 +23,7 @@ import {
   BrowserListConfig,
   HandleFailingRule,
   Context,
+  BrowsersListOpts,
 } from "../types";
 import { nodes } from "../providers";
 
@@ -156,13 +157,29 @@ export default {
       context.settings?.targets ||
       context.options[0];
 
+    if (
+      !context.settings?.browserslistOpts &&
+      // @ts-expect-error Checking for accidental misspellings
+      context.settings.browsersListOpts
+    ) {
+      console.error(
+        'Please ensure you spell `browserslistOpts` with a lowercase "l"!'
+      );
+    }
+    const browserslistOpts: BrowsersListOpts | undefined =
+      context.settings?.browserslistOpts;
+
     const lintAllEsApis: boolean =
       context.settings?.lintAllEsApis === true ||
       // Attempt to infer polyfilling of ES APIs from babel config
       (!context.settings?.polyfills?.includes("es:all") &&
         !isUsingTranspiler(context));
     const browserslistTargets = parseBrowsersListVersion(
-      determineTargetsFromConfig(context.getFilename(), browserslistConfig)
+      determineTargetsFromConfig(
+        context.getFilename(),
+        browserslistConfig,
+        browserslistOpts
+      )
     );
 
     // Stringify to support memoization; browserslistConfig is always an array of new objects.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { APIKind } from "ast-metadata-inferer/lib/types";
 import { Rule } from "eslint";
 import { TargetNameMappings } from "./constants";
+import type { Options as DefaultBrowsersListOpts } from "browserslist";
 
 export type BrowserListConfig =
   | string
@@ -66,5 +67,9 @@ export interface Context extends Rule.RuleContext {
     browsers?: Array<string>;
     polyfills?: Array<string>;
     lintAllEsApis?: boolean;
+    browserslistOpts?: BrowsersListOpts;
   };
 }
+
+export interface BrowsersListOpts
+  extends Exclude<DefaultBrowsersListOpts, "path"> {}


### PR DESCRIPTION
In your ESLint config, you can now add `settings.browserslistOpts` to configure which settings to pass to the [Browserslist JS API](https://github.com/browserslist/browserslist#js-api). 

For example, this would change the environment that Browserslist uses from `production` (the default) to `otherEnv`:

```json
{
  "settings": {
    "browserslistOpts": {
      "env": "otherEnv"
    }
  }
}
```

Closes #392 by allowing each ESLint config in a project to specify its own Browserslist env to choose from. 

(I tested this in a personal repo and it works great!)