### PR TITLE
fix: requestIdleCallback and requestAnimationFrame provider

### DIFF
--- a/src/providers/caniuse-provider.ts
+++ b/src/providers/caniuse-provider.ts
@@ -179,6 +179,18 @@ const CanIUseProvider: Array<AstMetadataApiWithTargetsResolver> = [
     object: "performance",
     property: "now",
   },
+  // requestIdleCallback()
+  {
+    caniuseId: "requestidlecallback",
+    astNodeType: AstNodeTypes.CallExpression,
+    object: "requestIdleCallback",
+  },
+  // requestAnimationFrame()
+  {
+    caniuseId: "requestanimationframe",
+    astNodeType: AstNodeTypes.CallExpression,
+    object: "requestAnimationFrame",
+  },
   {
     caniuseId: "typedarrays",
     astNodeType: AstNodeTypes.NewExpression,

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -667,5 +667,27 @@ ruleTester.run("compat", rule, {
         },
       ],
     },
+    {
+      code: "window.requestIdleCallback(() => {})",
+      settings: {
+        browsers: ["safari 12"],
+      },
+      errors: [
+        {
+          message: "requestIdleCallback is not supported in Safari 12",
+        },
+      ],
+    },
+    {
+      code: "window.requestAnimationFrame(() => {})",
+      settings: {
+        browsers: ["OperaMini all"],
+      },
+      errors: [
+        {
+          message: "requestAnimationFrame is not supported in op_mini all",
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
updated can i use provider for requestIdleCallback and requestAnimationFrame

Fixes
https://github.com/amilajack/eslint-plugin-compat/issues/554 - requestIdleCallback 
https://github.com/amilajack/eslint-plugin-compat/issues/302 - requestAnimationFrame issue mentioned in discussion
