### PR TITLE
perf: Use a memoized key lookup for rules

### DIFF
--- a/src/rules-lookup.ts
+++ b/src/rules-lookup.ts
@@ -1,0 +1,35 @@
+import { AstMetadataApiWithTargetsResolver } from "./types";
+
+// https://stackoverflow.com/q/49752151/25507
+type KeysOfType<T, TProp> = keyof T &
+  { [P in keyof T]: T[P] extends TProp ? P : never }[keyof T];
+
+export type RulesLookup = Map<
+  string | undefined,
+  AstMetadataApiWithTargetsResolver
+>;
+
+export function lookupKey(...args: Array<string | null | undefined>) {
+  return args.map((i) => (i == null ? null : i)).join("\0");
+}
+
+export function makeLookup(
+  rules: AstMetadataApiWithTargetsResolver[],
+  ...keys: Array<
+    KeysOfType<Required<AstMetadataApiWithTargetsResolver>, string>
+  >
+) {
+  const lookup = new Map<
+    string | undefined,
+    AstMetadataApiWithTargetsResolver
+  >();
+  // Iterate in inverse order to favor earlier rules in case of conflict.
+  for (let i = rules.length - 1; i >= 0; i--) {
+    const key =
+      keys.length === 1
+        ? rules[i][keys[0]]
+        : lookupKey(...keys.map((k) => rules[i][k]));
+    lookup.set(key, rules[i]);
+  }
+  return lookup;
+}

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -542,7 +542,7 @@ ruleTester.run("compat", rule, {
       settings: { browsers: ["ie 10"] },
       errors: [
         {
-          message: "Promise.resolve() is not supported in IE 10",
+          message: "Promise is not supported in IE 10",
           type: "MemberExpression",
         },
       ],
@@ -552,7 +552,7 @@ ruleTester.run("compat", rule, {
       settings: { browsers: ["ie 10"] },
       errors: [
         {
-          message: "Promise.all() is not supported in IE 10",
+          message: "Promise is not supported in IE 10",
           type: "MemberExpression",
         },
       ],
@@ -562,7 +562,7 @@ ruleTester.run("compat", rule, {
       settings: { browsers: ["ie 10"] },
       errors: [
         {
-          message: "Promise.race() is not supported in IE 10",
+          message: "Promise is not supported in IE 10",
           type: "MemberExpression",
         },
       ],
@@ -572,7 +572,7 @@ ruleTester.run("compat", rule, {
       settings: { browsers: ["ie 10"] },
       errors: [
         {
-          message: "Promise.reject() is not supported in IE 10",
+          message: "Promise is not supported in IE 10",
           type: "MemberExpression",
         },
       ],


### PR DESCRIPTION
On my project, this makes ESLint as a whole roughly 8% faster, and it seems to result in consistently faster benchmarks.

Note a behavior change - member expressions used to find the first matching rule, while they now favor the more general rule if relevant. (I believe this change is an improvement: "Promise is not supported in IE 10" is a more helpful message than "Promise.reject() is not supported in IE 10".)