### PR TITLE
feat: add `name` (for tooling)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ const plugin = {
 
 const configs = {
   "flat/recommended": {
+    name: 'compat/flat/recommended',
     plugins: { compat: plugin },
     ...recommended.flat,
   } as Linter.FlatConfig,


### PR DESCRIPTION
ESLint [recommends](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions) a name for flat configs.

Tools like https://github.com/eslint/config-inspector can use this to indicate the source of rules.

This PR adds that `name` to the current (flat) config. (It is not possible to add a name to the legacy config as it will err there.)