### PR TITLE
feat: added support for regexp literal

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,4 +54,5 @@ export enum AstNodeTypes {
   MemberExpression = "MemberExpression",
   CallExpression = "CallExpression",
   NewExpression = "NewExpression",
+  Literal = "Literal",
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
-import recommended from "./config/recommended";
-import pkg from "../package.json";
 import type { Linter } from "eslint";
+import pkg from "../package.json";
+import recommended from "./config/recommended";
 
 //------------------------------------------------------------------------------
 // Plugin Definition
@@ -32,7 +32,7 @@ const plugin = {
 
 const configs = {
   "flat/recommended": {
-    name: 'compat/flat/recommended',
+    name: "compat/flat/recommended",
     plugins: { compat: plugin },
     ...recommended.flat,
   } as Linter.FlatConfig,

--- a/src/providers/caniuse-provider.ts
+++ b/src/providers/caniuse-provider.ts
@@ -1,5 +1,5 @@
 import * as lite from "caniuse-lite";
-import { STANDARD_TARGET_NAME_MAPPING, AstNodeTypes } from "../constants";
+import { AstNodeTypes, STANDARD_TARGET_NAME_MAPPING } from "../constants";
 import { AstMetadataApiWithTargetsResolver, Target } from "../types";
 
 /**
@@ -240,6 +240,13 @@ const CanIUseProvider: Array<AstMetadataApiWithTargetsResolver> = [
     caniuseId: "typedarrays",
     astNodeType: AstNodeTypes.NewExpression,
     object: "Float64Array",
+  },
+  {
+    caniuseId: "js-regexp-lookbehind",
+    astNodeType: AstNodeTypes.Literal,
+    name: "Lookbehind",
+    object: "RegExp",
+    syntaxes: ["?<=", "?<!"],
   },
 ].map((rule) => ({
   ...rule,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { APIKind } from "ast-metadata-inferer/lib/types";
+import type { Options as DefaultBrowsersListOpts } from "browserslist";
 import { Rule } from "eslint";
 import { TargetNameMappings } from "./constants";
-import type { Options as DefaultBrowsersListOpts } from "browserslist";
 
 export type BrowserListConfig =
   | string
@@ -18,8 +18,13 @@ type AstMetadataApi = {
   type?: string;
   name?: string;
   object: string;
-  astNodeType: "MemberExpression" | "CallExpression" | "NewExpression";
+  astNodeType:
+    | "MemberExpression"
+    | "CallExpression"
+    | "NewExpression"
+    | "Literal";
   property?: string;
+  syntaxes?: string[];
   protoChainId: string;
   protoChain: Array<string>;
 };
@@ -49,6 +54,11 @@ export type ESLintNode = {
     name: string;
     type?: string;
   };
+  regex?: {
+    flags: string;
+    pattern: string;
+  };
+  raw: string;
 };
 
 export type SourceCode = import("eslint").SourceCode;

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
-import rule from "../src/rules/compat";
 import { parser } from "typescript-eslint";
+import rule from "../src/rules/compat";
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -688,6 +688,22 @@ ruleTester.run("compat", rule, {
       errors: [
         {
           message: "requestAnimationFrame is not supported in op_mini all",
+        },
+      ],
+    },
+    {
+      code: "/(?<=y)x/, new RegExp('(?<!y)x'), 'x', true, false, null, 1, 0n",
+      settings: {
+        browsers: ["Safari >= 16.3", "iOS >= 16.3"],
+      },
+      errors: [
+        {
+          message:
+            "Lookbehind is not supported in Safari 16.3, iOS Safari 16.3",
+        },
+        {
+          message:
+            "Lookbehind is not supported in Safari 16.3, iOS Safari 16.3",
         },
       ],
     },


### PR DESCRIPTION
Closes #555.

Adds `Literal` node type and `lintLiteral` validation function to use `syntaxes` rule property to define unsupported syntaxes.

Catches `/abc/` regexp literal and `new RegExp('abc')` expression, but not `const x = "x"; new RegExp(x)`.