### PR TITLE
Fix incorrect exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./lib/esm//src/index.d.mts",
+        "types": "./lib/esm/src/index.d.ts",
         "default": "./lib/esm/src/index.js"
       },
       "require": {


### PR DESCRIPTION
Fix incorrect exports field. `./lib/esm//src/index.d.mts` is not a valid path. I suspect this should be `./lib/esm/src/index.d.ts` per https://unpkg.com/browse/eslint-plugin-compat@6.0.2/lib/esm/src/index.d.ts