### PR TITLE
fix: `import` `types` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./lib/esm//src/index.d.mts",
+        "types": "./lib/esm//src/index.d.ts",
         "default": "./lib/esm/src/index.js"
       },
       "require": {


### PR DESCRIPTION
There is no `./lib/esm//src/index.d.mts` but `./lib/esm/src/index.d.ts`

https://app.unpkg.com/eslint-plugin-compat@6.0.2/files/lib/esm/src