### PR TITLE
Updates @mdn/browser-compat-data, browserslist, updates Jest snapshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@mdn/browser-compat-data": "^5.5.35",
+        "@mdn/browser-compat-data": "^6.1.1",
         "ast-metadata-inferer": "^0.8.1",
-        "browserslist": "^4.24.2",
+        "browserslist": "^4.25.2",
         "caniuse-lite": "^1.0.30001687",
         "find-up": "^5.0.0",
         "globals": "^15.7.0",
@@ -1364,9 +1364,9 @@
       "dev": true
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.6.23",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.6.23.tgz",
-      "integrity": "sha512-6h/L/id7JiuCcLKNZSliMfl9S159/ditQ/wc4TPlHJ/gcqoo4PNGggVaY6VcvVef9VFGuhh+UW27iAnEzQn+Kw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.1.1.tgz",
+      "integrity": "sha512-9/Uu3ROTiOR4kzvWclJz2wsx65bLUZzsQOxCcIFmy0JBQ2soH8tw6aSmkxOjDS1QM11InjY9/lcWcnKZL8zUNA==",
       "license": "CC0-1.0"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -2799,6 +2799,12 @@
         "@mdn/browser-compat-data": "^5.6.19"
       }
     },
+    "node_modules/ast-metadata-inferer/node_modules/@mdn/browser-compat-data": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.7.6.tgz",
+      "integrity": "sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==",
+      "license": "CC0-1.0"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2973,9 +2979,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+      "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2992,10 +2998,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.1"
+        "caniuse-lite": "^1.0.30001733",
+        "electron-to-chromium": "^1.5.199",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3110,9 +3116,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001687",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-      "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+      "version": "1.0.30001734",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+      "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3682,9 +3688,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.72",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.72.tgz",
-      "integrity": "sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==",
+      "version": "1.5.200",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
+      "integrity": "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -5311,6 +5317,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11047,9 +11054,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "funding": [
         {
           "type": "opencollective",
@@ -11067,7 +11074,7 @@
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
     ]
   },
   "dependencies": {
-    "@mdn/browser-compat-data": "^5.5.35",
+    "@mdn/browser-compat-data": "^6.1.1",
     "ast-metadata-inferer": "^0.8.1",
-    "browserslist": "^4.24.2",
+    "browserslist": "^4.25.2",
     "caniuse-lite": "^1.0.30001687",
     "find-up": "^5.0.0",
     "globals": "^15.7.0",

--- a/src/providers/mdn-provider.ts
+++ b/src/providers/mdn-provider.ts
@@ -80,7 +80,7 @@ export function isSupportedByMDN(
   if (!mdnRecords.has(node.protoChainId)) return true;
   const record = mdnRecords.get(node.protoChainId);
   if (!record || !record.compat.support) return true;
-  const compatRecord = record.compat.support[target];
+  const compatRecord = record.compat.support[target as keyof typeof record.compat.support];
   if (!compatRecord) return true;
   if (!Array.isArray(compatRecord) && !("version_added" in compatRecord))
     return true;

--- a/test/__snapshots__/helpers.spec.ts.snap
+++ b/test/__snapshots__/helpers.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Versioning should get lowest target versions 1`] = `
 [
@@ -23,19 +23,19 @@ exports[`Versioning should get lowest target versions 1`] = `
 exports[`Versioning should support multi env config in browserslist package.json 1`] = `
 [
   {
-    "parsedVersion": 24,
+    "parsedVersion": 25,
     "target": "samsung",
-    "version": "24",
+    "version": "25",
   },
   {
-    "parsedVersion": 17.5,
+    "parsedVersion": 18.2,
     "target": "safari",
-    "version": "17.5",
+    "version": "18.2",
   },
   {
-    "parsedVersion": 111,
+    "parsedVersion": 114,
     "target": "opera",
-    "version": "111",
+    "version": "114",
   },
   {
     "parsedVersion": 80,
@@ -53,9 +53,9 @@ exports[`Versioning should support multi env config in browserslist package.json
     "version": "2.5",
   },
   {
-    "parsedVersion": 17.5,
+    "parsedVersion": 18.2,
     "target": "ios_saf",
-    "version": "17.5",
+    "version": "18.2",
   },
   {
     "parsedVersion": 10,
@@ -68,19 +68,19 @@ exports[`Versioning should support multi env config in browserslist package.json
     "version": "9",
   },
   {
-    "parsedVersion": 115,
-    "target": "firefox",
-    "version": "115",
-  },
-  {
     "parsedVersion": 128,
-    "target": "edge",
+    "target": "firefox",
     "version": "128",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 135,
+    "target": "edge",
+    "version": "135",
+  },
+  {
+    "parsedVersion": 112,
     "target": "chrome",
-    "version": "109",
+    "version": "112",
   },
   {
     "parsedVersion": 7,
@@ -93,9 +93,9 @@ exports[`Versioning should support multi env config in browserslist package.json
     "version": "13.52",
   },
   {
-    "parsedVersion": 131,
+    "parsedVersion": 138,
     "target": "android",
-    "version": "131",
+    "version": "138",
   },
   {
     "parsedVersion": 15.5,
@@ -108,14 +108,14 @@ exports[`Versioning should support multi env config in browserslist package.json
     "version": "14.9",
   },
   {
-    "parsedVersion": 132,
+    "parsedVersion": 140,
     "target": "and_ff",
-    "version": "132",
+    "version": "140",
   },
   {
-    "parsedVersion": 131,
+    "parsedVersion": 138,
     "target": "and_chr",
-    "version": "131",
+    "version": "138",
   },
 ]
 `;
@@ -133,19 +133,19 @@ exports[`Versioning should support resolving browserslist config in subdirectory
 exports[`Versioning should support resolving browserslist config in subdirectory 2`] = `
 [
   {
-    "parsedVersion": 26,
+    "parsedVersion": 27,
     "target": "samsung",
-    "version": "26",
+    "version": "27",
   },
   {
-    "parsedVersion": 17.6,
+    "parsedVersion": 18.4,
     "target": "safari",
-    "version": "17.6",
+    "version": "18.4",
   },
   {
-    "parsedVersion": 113,
+    "parsedVersion": 116,
     "target": "opera",
-    "version": "113",
+    "version": "116",
   },
   {
     "parsedVersion": 80,
@@ -163,19 +163,19 @@ exports[`Versioning should support resolving browserslist config in subdirectory
     "version": "2.5",
   },
   {
-    "parsedVersion": 15.6,
+    "parsedVersion": 18.4,
     "target": "ios_saf",
-    "version": "15.6-15.8",
+    "version": "18.4",
   },
   {
-    "parsedVersion": 115,
+    "parsedVersion": 128,
     "target": "firefox",
-    "version": "115",
+    "version": "128",
   },
   {
-    "parsedVersion": 130,
+    "parsedVersion": 137,
     "target": "edge",
-    "version": "130",
+    "version": "137",
   },
   {
     "parsedVersion": 109,
@@ -183,9 +183,9 @@ exports[`Versioning should support resolving browserslist config in subdirectory
     "version": "109",
   },
   {
-    "parsedVersion": 131,
+    "parsedVersion": 138,
     "target": "android",
-    "version": "131",
+    "version": "138",
   },
   {
     "parsedVersion": 15.5,
@@ -198,14 +198,14 @@ exports[`Versioning should support resolving browserslist config in subdirectory
     "version": "14.9",
   },
   {
-    "parsedVersion": 132,
+    "parsedVersion": 140,
     "target": "and_ff",
-    "version": "132",
+    "version": "140",
   },
   {
-    "parsedVersion": 131,
+    "parsedVersion": 138,
     "target": "and_chr",
-    "version": "131",
+    "version": "138",
   },
 ]
 `;
@@ -213,19 +213,19 @@ exports[`Versioning should support resolving browserslist config in subdirectory
 exports[`Versioning should support single array config in browserslist package.json 1`] = `
 [
   {
-    "parsedVersion": 24,
+    "parsedVersion": 25,
     "target": "samsung",
-    "version": "24",
+    "version": "25",
   },
   {
-    "parsedVersion": 17.5,
+    "parsedVersion": 18.2,
     "target": "safari",
-    "version": "17.5",
+    "version": "18.2",
   },
   {
-    "parsedVersion": 111,
+    "parsedVersion": 114,
     "target": "opera",
-    "version": "111",
+    "version": "114",
   },
   {
     "parsedVersion": 80,
@@ -243,9 +243,9 @@ exports[`Versioning should support single array config in browserslist package.j
     "version": "2.5",
   },
   {
-    "parsedVersion": 17.5,
+    "parsedVersion": 18.2,
     "target": "ios_saf",
-    "version": "17.5",
+    "version": "18.2",
   },
   {
     "parsedVersion": 10,
@@ -258,19 +258,19 @@ exports[`Versioning should support single array config in browserslist package.j
     "version": "9",
   },
   {
-    "parsedVersion": 115,
-    "target": "firefox",
-    "version": "115",
-  },
-  {
     "parsedVersion": 128,
-    "target": "edge",
+    "target": "firefox",
     "version": "128",
   },
   {
-    "parsedVersion": 109,
+    "parsedVersion": 135,
+    "target": "edge",
+    "version": "135",
+  },
+  {
+    "parsedVersion": 112,
     "target": "chrome",
-    "version": "109",
+    "version": "112",
   },
   {
     "parsedVersion": 7,
@@ -283,9 +283,9 @@ exports[`Versioning should support single array config in browserslist package.j
     "version": "13.52",
   },
   {
-    "parsedVersion": 131,
+    "parsedVersion": 138,
     "target": "android",
-    "version": "131",
+    "version": "138",
   },
   {
     "parsedVersion": 15.5,
@@ -298,14 +298,14 @@ exports[`Versioning should support single array config in browserslist package.j
     "version": "14.9",
   },
   {
-    "parsedVersion": 132,
+    "parsedVersion": 140,
     "target": "and_ff",
-    "version": "132",
+    "version": "140",
   },
   {
-    "parsedVersion": 131,
+    "parsedVersion": 138,
     "target": "and_chr",
-    "version": "131",
+    "version": "138",
   },
 ]
 `;
@@ -313,19 +313,19 @@ exports[`Versioning should support single array config in browserslist package.j
 exports[`Versioning should support string config in rule option 1`] = `
 [
   {
-    "parsedVersion": 26,
+    "parsedVersion": 27,
     "target": "samsung",
-    "version": "26",
+    "version": "27",
   },
   {
-    "parsedVersion": 17.6,
+    "parsedVersion": 18.4,
     "target": "safari",
-    "version": "17.6",
+    "version": "18.4",
   },
   {
-    "parsedVersion": 113,
+    "parsedVersion": 116,
     "target": "opera",
-    "version": "113",
+    "version": "116",
   },
   {
     "parsedVersion": 80,
@@ -343,19 +343,19 @@ exports[`Versioning should support string config in rule option 1`] = `
     "version": "2.5",
   },
   {
-    "parsedVersion": 15.6,
+    "parsedVersion": 18.4,
     "target": "ios_saf",
-    "version": "15.6-15.8",
+    "version": "18.4",
   },
   {
-    "parsedVersion": 115,
+    "parsedVersion": 128,
     "target": "firefox",
-    "version": "115",
+    "version": "128",
   },
   {
-    "parsedVersion": 130,
+    "parsedVersion": 137,
     "target": "edge",
-    "version": "130",
+    "version": "137",
   },
   {
     "parsedVersion": 109,
@@ -363,9 +363,9 @@ exports[`Versioning should support string config in rule option 1`] = `
     "version": "109",
   },
   {
-    "parsedVersion": 131,
+    "parsedVersion": 138,
     "target": "android",
-    "version": "131",
+    "version": "138",
   },
   {
     "parsedVersion": 15.5,
@@ -378,14 +378,14 @@ exports[`Versioning should support string config in rule option 1`] = `
     "version": "14.9",
   },
   {
-    "parsedVersion": 132,
+    "parsedVersion": 140,
     "target": "and_ff",
-    "version": "132",
+    "version": "140",
   },
   {
-    "parsedVersion": 131,
+    "parsedVersion": 138,
     "target": "and_chr",
-    "version": "131",
+    "version": "138",
   },
 ]
 `;


### PR DESCRIPTION
eslint-plugin-compat has fallen far behind `@mdn/browser-compat-data` which means it's missing a lot of browser APIs that have been added and isn't useable for most purposes.

This PR updates it to the latest version of MDN and accommodates a breaking change between BCD 5.x.x and 6.x.x.  It also updates the Jest snapshot to ensure tests pass.

Let me know if you have any questions.