### PR TITLE
fix: wrong exports enrty for  import`types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./lib/esm//src/index.d.mts",
+        "types": "./lib/esm/src/index.d.ts",
         "default": "./lib/esm/src/index.js"
       },
       "require": {


### PR DESCRIPTION
related https://github.com/un-ts/eslint-plugin-import-x/issues/425#issuecomment-3212903742

<img width="890" height="408" alt="image" src="https://github.com/user-attachments/assets/90580a6f-639b-4309-a04b-ef93cd886be7" />
