### PR TITLE
perf: Use `Map` instead of `AstMetadataApiWithTargetsResolver[]` for faster matching

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -71,7 +71,7 @@ export function lintCallExpression(
   if (!node.callee) return;
   const calleeName = node.callee.name;
   if (!calleeName) return;
-  const failingRule = rulesMap.get(calleeName.toLowerCase());
+  const failingRule = rulesMap.get(calleeName);
   if (failingRule)
     checkNotInsideIfStatementAndReport(
       context,
@@ -92,7 +92,7 @@ export function lintNewExpression(
   if (!node.callee) return;
   const calleeName = node.callee.name;
   if (!calleeName) return;
-  const failingRule = rulesMap.get(calleeName.toLowerCase());
+  const failingRule = rulesMap.get(calleeName);
   if (failingRule)
     checkNotInsideIfStatementAndReport(
       context,
@@ -111,7 +111,7 @@ export function lintExpressionStatement(
   node: ESLintNode
 ) {
   if (!node?.expression?.name) return;
-  const failingRule = rulesMap.get(node.expression!.name.toLowerCase());
+  const failingRule = rulesMap.get(node.expression!.name);
   if (failingRule)
     checkNotInsideIfStatementAndReport(
       context,
@@ -171,6 +171,31 @@ function protoChainFromMemberExpression(node: ESLintNode): string[] {
 
 const browserGlobals = new Set(Object.keys(globals.browser));
 
+/**
+ * Secondary lookup for built-in `obj.prop` when the map was keyed with different
+ * casing for `object` (e.g. `Document` in metadata vs `document` in the AST). The
+ * property name must still match the source exactly.
+ */
+function findMemberRuleByGlobalObjectCasing(
+  rulesMap: RuleMap,
+  objectName: string,
+  propertyName: string
+): AstMetadataApiWithTargetsResolver | undefined {
+  for (const [k, rule] of rulesMap) {
+    const dot = k.indexOf(".");
+    if (dot === -1) continue;
+    const kObj = k.slice(0, dot);
+    const kProp = k.slice(dot + 1);
+    if (
+      kObj.toLowerCase() === objectName.toLowerCase() &&
+      kProp === propertyName
+    ) {
+      return rule;
+    }
+  }
+  return undefined;
+}
+
 export function lintMemberExpression(
   context: Context,
   handleFailingRule: HandleFailingRule,
@@ -191,7 +216,7 @@ export function lintMemberExpression(
         ? rawProtoChain.slice(1)
         : rawProtoChain;
     const protoChainId = protoChain.join(".");
-    const failingRule = rulesMap.get(protoChainId.toLowerCase());
+    const failingRule = rulesMap.get(protoChainId);
     if (failingRule) {
       checkNotInsideIfStatementAndReport(
         context,
@@ -207,8 +232,16 @@ export function lintMemberExpression(
     if (!objectName || !propertyName) return;
     const isBrowserGlobal = browserGlobals.has(objectName);
     let failingRule =
-      rulesMap.get(`${objectName}.${propertyName}`.toLowerCase()) ??
-      rulesMap.get(objectName.toLowerCase());
+      rulesMap.get(`${objectName}.${propertyName}`) ??
+      rulesMap.get(objectName);
+
+    if (!failingRule && isBrowserGlobal) {
+      failingRule = findMemberRuleByGlobalObjectCasing(
+        rulesMap,
+        objectName,
+        propertyName
+      );
+    }
     if (
       failingRule &&
       !isBrowserGlobal &&

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -58,16 +58,19 @@ function checkNotInsideIfStatementAndReport(
   }
 }
 
+export type RuleMap = Map<string, AstMetadataApiWithTargetsResolver>;
+
 export function lintCallExpression(
   context: Context,
   handleFailingRule: HandleFailingRule,
-  rules: AstMetadataApiWithTargetsResolver[],
+  rulesMap: RuleMap,
   sourceCode: SourceCode,
   node: ESLintNode
 ) {
   if (!node.callee) return;
   const calleeName = node.callee.name;
-  const failingRule = rules.find((rule) => rule.object === calleeName);
+  if (!calleeName) return;
+  const failingRule = rulesMap.get(calleeName.toLowerCase());
   if (failingRule)
     checkNotInsideIfStatementAndReport(
       context,
@@ -81,13 +84,14 @@ export function lintCallExpression(
 export function lintNewExpression(
   context: Context,
   handleFailingRule: HandleFailingRule,
-  rules: Array<AstMetadataApiWithTargetsResolver>,
+  rulesMap: RuleMap,
   sourceCode: SourceCode,
   node: ESLintNode
 ) {
   if (!node.callee) return;
   const calleeName = node.callee.name;
-  const failingRule = rules.find((rule) => rule.object === calleeName);
+  if (!calleeName) return;
+  const failingRule = rulesMap.get(calleeName.toLowerCase());
   if (failingRule)
     checkNotInsideIfStatementAndReport(
       context,
@@ -101,14 +105,12 @@ export function lintNewExpression(
 export function lintExpressionStatement(
   context: Context,
   handleFailingRule: HandleFailingRule,
-  rules: AstMetadataApiWithTargetsResolver[],
+  rulesMap: RuleMap,
   sourceCode: SourceCode,
   node: ESLintNode
 ) {
   if (!node?.expression?.name) return;
-  const failingRule = rules.find(
-    (rule) => rule.object === node?.expression?.name
-  );
+  const failingRule = rulesMap.get(node.expression!.name.toLowerCase());
   if (failingRule)
     checkNotInsideIfStatementAndReport(
       context,
@@ -129,17 +131,18 @@ function checkRegexpLiteral(node: ESLintNode): boolean {
 export function lintLiteral(
   context: Context,
   handleFailingRule: HandleFailingRule,
-  rules: AstMetadataApiWithTargetsResolver[],
+  rulesMap: RuleMap,
   sourceCode: SourceCode,
   node: ESLintNode
 ) {
   const isRegexpLiteral = checkRegexpLiteral(node);
-  const failingRule = rules.find((rule) =>
-    rule.syntaxes?.some(
-      (syntax) => (isRegexpLiteral ? node.raw.includes(syntax) : false) // non-regexp literals are not supported yet
-    )
-  );
-  if (failingRule) handleFailingRule(failingRule, node);
+  if (!isRegexpLiteral) return;
+  for (const [syntax, rule] of rulesMap) {
+    if (node.raw.includes(syntax)) {
+      handleFailingRule(rule, node);
+      return;
+    }
+  }
 }
 
 function isStringLiteral(node: ESLintNode): boolean {
@@ -168,7 +171,7 @@ function protoChainFromMemberExpression(node: ESLintNode): string[] {
 export function lintMemberExpression(
   context: Context,
   handleFailingRule: HandleFailingRule,
-  rules: Array<AstMetadataApiWithTargetsResolver>,
+  rulesMap: RuleMap,
   sourceCode: SourceCode,
   node: ESLintNode
 ) {
@@ -185,9 +188,7 @@ export function lintMemberExpression(
         ? rawProtoChain.slice(1)
         : rawProtoChain;
     const protoChainId = protoChain.join(".");
-    const failingRule = rules.find(
-      (rule) => rule.protoChainId === protoChainId
-    );
+    const failingRule = rulesMap.get(protoChainId.toLowerCase());
     if (failingRule) {
       checkNotInsideIfStatementAndReport(
         context,
@@ -200,11 +201,10 @@ export function lintMemberExpression(
   } else {
     const objectName = node.object.name;
     const propertyName = node.property.name;
-    const failingRule = rules.find(
-      (rule) =>
-        rule.object.toLowerCase() === objectName.toLowerCase() &&
-        (rule.property == null || rule.property === propertyName)
-    );
+    if (!objectName || !propertyName) return;
+    const failingRule =
+      rulesMap.get(`${objectName}.${propertyName}`.toLowerCase()) ??
+      rulesMap.get(objectName.toLowerCase());
     if (failingRule)
       checkNotInsideIfStatementAndReport(
         context,

--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -17,6 +17,7 @@ import {
   lintMemberExpression,
   lintNewExpression,
   parseBrowsersListVersion,
+  type RuleMap,
 } from "../helpers"; // will be deprecated and introduced to this file
 import { nodes } from "../providers";
 import {
@@ -110,22 +111,23 @@ function isUsingTranspiler(context: Context): boolean {
   return false;
 }
 
-type RulesFilteredByTargets = {
-  CallExpression: AstMetadataApiWithTargetsResolver[];
-  NewExpression: AstMetadataApiWithTargetsResolver[];
-  MemberExpression: AstMetadataApiWithTargetsResolver[];
-  ExpressionStatement: AstMetadataApiWithTargetsResolver[];
-  Literal: AstMetadataApiWithTargetsResolver[];
+type RuleMapsForTargets = {
+  callExpression: RuleMap;
+  newExpression: RuleMap;
+  expressionStatement: RuleMap;
+  memberExpression: RuleMap;
+  literal: RuleMap;
 };
 
 /**
  * A small optimization that only lints APIs that are not supported by targeted browsers.
  * For example, if the user is targeting chrome 50, which supports the fetch API, it is
  * wasteful to lint calls to fetch.
+ * Returns Maps for O(1) rule lookup per node (first match wins).
  */
 const getRulesForTargets = memoize(
-  (targetsJSON: string, lintAllEsApis: boolean): RulesFilteredByTargets => {
-    const result = {
+  (targetsJSON: string, lintAllEsApis: boolean): RuleMapsForTargets => {
+    const byType = {
       CallExpression: [] as AstMetadataApiWithTargetsResolver[],
       NewExpression: [] as AstMetadataApiWithTargetsResolver[],
       MemberExpression: [] as AstMetadataApiWithTargetsResolver[],
@@ -138,10 +140,51 @@ const getRulesForTargets = memoize(
       .filter((node) => (lintAllEsApis ? true : node.kind !== "es"))
       .forEach((node) => {
         if (!node.getUnsupportedTargets(node, targets).length) return;
-        result[node.astNodeType].push(node);
+        byType[node.astNodeType].push(node);
       });
 
-    return result;
+    const callExpression = new Map<string, AstMetadataApiWithTargetsResolver>();
+    for (const rule of byType.CallExpression) {
+      const key = rule.object.toLowerCase();
+      if (!callExpression.has(key)) callExpression.set(key, rule);
+    }
+    const newExpression = new Map<string, AstMetadataApiWithTargetsResolver>();
+    for (const rule of byType.NewExpression) {
+      const key = rule.object.toLowerCase();
+      if (!newExpression.has(key)) newExpression.set(key, rule);
+    }
+    const expressionStatement = new Map<string, AstMetadataApiWithTargetsResolver>();
+    for (const rule of [...byType.MemberExpression, ...byType.CallExpression]) {
+      const key = rule.object.toLowerCase();
+      if (!expressionStatement.has(key))
+        expressionStatement.set(key, rule);
+    }
+    const memberExpression = new Map<string, AstMetadataApiWithTargetsResolver>();
+    for (const rule of [
+      ...byType.MemberExpression,
+      ...byType.CallExpression,
+      ...byType.NewExpression,
+    ]) {
+      const protoChainKey = rule.protoChainId.toLowerCase();
+      if (!memberExpression.has(protoChainKey))
+        memberExpression.set(protoChainKey, rule);
+      const key = (rule.property ? `${rule.object}.${rule.property}` : rule.object).toLowerCase();
+      if (!memberExpression.has(key)) memberExpression.set(key, rule);
+    }
+    const literal = new Map<string, AstMetadataApiWithTargetsResolver>();
+    for (const rule of byType.Literal) {
+      for (const syntax of rule.syntaxes ?? []) {
+        if (!literal.has(syntax)) literal.set(syntax, rule);
+      }
+    }
+
+    return {
+      callExpression,
+      newExpression,
+      expressionStatement,
+      memberExpression,
+      literal,
+    };
   }
 );
 
@@ -198,7 +241,7 @@ export default {
     );
 
     // Stringify to support memoization; browserslistConfig is always an array of new objects.
-    const targetedRules = getRulesForTargets(
+    const ruleMaps = getRulesForTargets(
       JSON.stringify(browserslistTargets),
       lintAllEsApis
     );
@@ -232,39 +275,35 @@ export default {
         null,
         context,
         handleFailingRule,
-        targetedRules.CallExpression,
+        ruleMaps.callExpression,
         sourceCode
       ),
       NewExpression: lintNewExpression.bind(
         null,
         context,
         handleFailingRule,
-        targetedRules.NewExpression,
+        ruleMaps.newExpression,
         sourceCode
       ),
       ExpressionStatement: lintExpressionStatement.bind(
         null,
         context,
         handleFailingRule,
-        [...targetedRules.MemberExpression, ...targetedRules.CallExpression],
+        ruleMaps.expressionStatement,
         sourceCode
       ),
       MemberExpression: lintMemberExpression.bind(
         null,
         context,
         handleFailingRule,
-        [
-          ...targetedRules.MemberExpression,
-          ...targetedRules.CallExpression,
-          ...targetedRules.NewExpression,
-        ],
+        ruleMaps.memberExpression,
         sourceCode
       ),
       Literal: lintLiteral.bind(
         null,
         context,
         handleFailingRule,
-        targetedRules.Literal,
+        ruleMaps.literal,
         sourceCode
       ),
       // Keep track of all the defined variables. Do not report errors for nodes that are not defined

--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -149,19 +149,16 @@ const getRulesForTargets = memoize(
 
     const callExpression = new Map<string, AstMetadataApiWithTargetsResolver>();
     for (const rule of byType.CallExpression) {
-      const key = rule.object.toLowerCase();
-      if (!callExpression.has(key)) callExpression.set(key, rule);
+      if (!callExpression.has(rule.object)) callExpression.set(rule.object, rule);
     }
     const newExpression = new Map<string, AstMetadataApiWithTargetsResolver>();
     for (const rule of byType.NewExpression) {
-      const key = rule.object.toLowerCase();
-      if (!newExpression.has(key)) newExpression.set(key, rule);
+      if (!newExpression.has(rule.object)) newExpression.set(rule.object, rule);
     }
     const expressionStatement = new Map<string, AstMetadataApiWithTargetsResolver>();
     for (const rule of [...byType.MemberExpression, ...byType.CallExpression]) {
-      const key = rule.object.toLowerCase();
-      if (!expressionStatement.has(key))
-        expressionStatement.set(key, rule);
+      if (!expressionStatement.has(rule.object))
+        expressionStatement.set(rule.object, rule);
     }
     const memberExpression = new Map<string, AstMetadataApiWithTargetsResolver>();
     for (const rule of [
@@ -169,10 +166,11 @@ const getRulesForTargets = memoize(
       ...byType.CallExpression,
       ...byType.NewExpression,
     ]) {
-      const protoChainKey = rule.protoChainId.toLowerCase();
-      if (!memberExpression.has(protoChainKey))
-        memberExpression.set(protoChainKey, rule);
-      const key = (rule.property ? `${rule.object}.${rule.property}` : rule.object).toLowerCase();
+      if (!memberExpression.has(rule.protoChainId))
+        memberExpression.set(rule.protoChainId, rule);
+      const key = rule.property
+        ? `${rule.object}.${rule.property}`
+        : rule.object;
       if (!memberExpression.has(key)) memberExpression.set(key, rule);
     }
     const literal = new Map<string, AstMetadataApiWithTargetsResolver>();
@@ -189,7 +187,10 @@ const getRulesForTargets = memoize(
       memberExpression,
       literal,
     };
-  }
+  },
+  // lodash.memoize keys on the first argument only by default; include lintAllEsApis
+  // so the cache does not return the wrong rules when targets match but ES filtering differs.
+  (targetsJSON, lintAllEsApis) => `${targetsJSON}\0${lintAllEsApis}`
 );
 
 export default {

--- a/test/compat-lookup-behavior.spec.ts
+++ b/test/compat-lookup-behavior.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Regressions for case-sensitive API matching and memoization of getRulesForTargets
+ * (see PR #679 review: lodash.memoize first-arg only; toLowerCase map keys / lookups).
+ */
+import { ESLint } from "eslint";
+import { parser } from "typescript-eslint";
+import * as eslint from "eslint";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import rule from "../src/rules/compat";
+import compat from "../src";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const eslintMod = eslint as any;
+const eslintVersion = parseInt(
+  (eslintMod.Linter?.version || eslintMod.version || "9").split(".")[0],
+  10
+);
+
+// RuleTester: match e2e.spec.ts
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config: any =
+  eslintVersion >= 9
+    ? {
+        languageOptions: {
+          parser,
+          parserOptions: { ecmaVersion: 2020, sourceType: "script" },
+        },
+        settings: {
+          lintAllEsApis: true,
+        },
+      }
+    : {
+        parser: require.resolve("@typescript-eslint/parser"),
+        parserOptions: { ecmaVersion: 2020, sourceType: "script" },
+        settings: {
+          lintAllEsApis: true,
+        },
+      };
+
+const ruleTester = new eslint.RuleTester(config);
+
+ruleTester.run("compat (case-sensitive + memo regressions)", rule, {
+  valid: [
+    {
+      // Lowercase identifier is not the URL constructor; must not match the URL() rule
+      // (JS identifiers are case-sensitive).
+      code: "void new url();",
+      settings: { browsers: ["ie 8"], lintAllEsApis: true },
+    },
+    {
+      // document rules always carry a property; wrong case must not match document.querySelector
+      code: "void document.QuerySelector;",
+      settings: { browsers: ["ie 8"], lintAllEsApis: true },
+    },
+  ],
+  invalid: [
+    {
+      code: "void new URL();",
+      settings: { browsers: ["ie 8"], lintAllEsApis: true },
+      errors: [
+        {
+          message: "URL is not supported in IE 8",
+        },
+      ],
+    },
+    {
+      code: "void document.querySelector;",
+      settings: { browsers: ["ie 8"], lintAllEsApis: true },
+      errors: [
+        {
+          message: "document.querySelector() is not supported in IE 8",
+        },
+      ],
+    },
+  ],
+});
+
+describe("getRulesForTargets memo (cache key includes boolean second arg)", () => {
+  it("default vs polyfills: es:all does not reuse a stale map from the other setting", async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "compat-memo-lintAllEs-")
+    );
+    try {
+      const filePath = path.join(tmpDir, "a.js");
+      await fs.writeFile(filePath, "Array.from([1, 2, 3]);");
+
+      // lintAllEsApis is derived: false in settings is OR'd with "!babel && !es:all" and usually becomes true.
+      // Polyfills: ["es:all"] is the way to get computed lintAllEsApis false without babel in-tree.
+      const makeEslint = (settings: { polyfills?: string[] }) =>
+        new ESLint({
+          overrideConfigFile: true,
+          ignore: false,
+          cwd: tmpDir,
+          baseConfig: [
+            compat.configs["flat/recommended"],
+            {
+              languageOptions: {
+                parserOptions: { ecmaVersion: 2022, sourceType: "script" },
+              },
+              settings: {
+                browsers: ["ie 8"],
+                ...settings,
+              },
+            },
+          ],
+        });
+
+      // Warm cache with ES rules included (Array.from is kind "es" in the rule set)
+      const r1 = await makeEslint({}).lintFiles([filePath]);
+      expect(r1[0].messages.length).toBeGreaterThan(0);
+      expect(r1[0].messages[0].ruleId).toBe("compat/compat");
+
+      // Must not return the memoized map from the run with ES rules: es:all should drop ES APIs
+      const r2 = await makeEslint({ polyfills: ["es:all"] }).lintFiles([filePath]);
+      expect(r2[0].messages).toHaveLength(0);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
This refactors the `getRulesForTargets` function to return `Map<string, AstMetadataApiWithTargetsResolver>` for each expression matching.

Before it returned:

```ts
{
  CallExpression: AstMetadataApiWithTargetsResolver[];
  NewExpression: AstMetadataApiWithTargetsResolver[];
  MemberExpression: AstMetadataApiWithTargetsResolver[];
  ExpressionStatement: AstMetadataApiWithTargetsResolver[];
  Literal: AstMetadataApiWithTargetsResolver[];
}
```

Now it returns:

```
{
  callExpression: RuleMap;
  newExpression: RuleMap;
  expressionStatement: RuleMap;
  memberExpression: RuleMap;
  literal: RuleMap;
};
```

This also requires changes now in `helpers.tsx` and makes a lot of `rules.find(` calls much faster. O(1) instead of O(n).

I benchmarked the changes as well (Thanks for providing the benchmarks):

Before: https://gist.github.com/igeligel/8c2dd38d1da1363f3a57c3820b208688#file-1-before-txt
After: https://gist.github.com/igeligel/8c2dd38d1da1363f3a57c3820b208688#file-2-after-txt


Repo | Before mean (s) | After mean (s) | Change
-- | -- | -- | --
bootstrap | 0.609 | 0.335 | ~45% faster
jquery | 1.089 | 0.741 | ~32% faster
handlebars.js | 0.462 | 0.376 | ~19% faster
aframe | 8.070 | 6.280 | ~22% faster
pixi.js | 2.284 | 1.743 | ~24% faster
create-react-app | 2.685 | 2.202 | ~18% faster
electron-react-boilerplate | 0.0316 | 0.0271 | ~14% faster
preact | 0.00689 | 0.00528 | ~23% faster

There are some more improvements as well that I will follow up in other Pull Requests.