### PR TITLE
fix: case-insensitive match for lowercase browser globals (#649)

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -202,7 +202,7 @@ export function lintMemberExpression(
     const propertyName = node.property.name;
     const failingRule = rules.find(
       (rule) =>
-        rule.object === objectName &&
+        rule.object.toLowerCase() === objectName.toLowerCase() &&
         (rule.property == null || rule.property === propertyName)
     );
     if (failingRule)

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -745,5 +745,15 @@ ruleTester.run("compat", rule, {
         },
       ],
     },
+    {
+      code: "crypto.randomUUID()",
+      settings: { browsers: ["chrome 52", "safari 14"] },
+      errors: [
+        {
+          message: "Crypto.randomUUID() is not supported in Safari 14, Chrome 52",
+          type: "MemberExpression",
+        },
+      ],
+    },    
   ],
 });


### PR DESCRIPTION
Compare browser globals case-insensitively;
- lowercase globals like "crypto" should match MDN interface name like "Crypto"
- e2e test for crypto.randomUUID() on Chrome 52 and Safari 14

Closes #649 