### PR TITLE
fix: remove unused @mdn/browser-compat-data dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
-        "@mdn/browser-compat-data": "^6.1.1",
         "ast-metadata-inferer": "^0.8.1",
         "browserslist": "^4.25.2",
         "find-up": "^5.0.0",
@@ -1903,12 +1902,6 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
-    },
-    "node_modules/@mdn/browser-compat-data": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.1.1.tgz",
-      "integrity": "sha512-9/Uu3ROTiOR4kzvWclJz2wsx65bLUZzsQOxCcIFmy0JBQ2soH8tw6aSmkxOjDS1QM11InjY9/lcWcnKZL8zUNA==",
-      "license": "CC0-1.0"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     ]
   },
   "dependencies": {
-    "@mdn/browser-compat-data": "^6.1.1",
     "ast-metadata-inferer": "^0.8.1",
     "browserslist": "^4.25.2",
     "find-up": "^5.0.0",


### PR DESCRIPTION
eslint-plugin-compat does not use @mdn/browser-compat-data at all. Its only usage throughout history was added in fa15cc660571eaf58484c1dd89e3b84c66650cdc and removed in e8e4d62266417f04fe62e3b7ed6a423de1d903b9. And that was just for a type declaration.

It also wastes node_modules disk space. eslint-plugin-compat depends on ast-metadata-inferer which currently depends on @mdn/browser-compat-data `^5.6.19`. But eslint-plugin-compat also directly depends on @mdn/browser-compat-data `^6.1.1`. They have different major versions, so both are wastefully installed side by side.

The contrast with PR #682 is ironic. :) Please merge that one too btw.